### PR TITLE
replaceOne feature

### DIFF
--- a/cc/src/main/scala/me/sgrouples/rogue/cc/ExecutableQuery.scala
+++ b/cc/src/main/scala/me/sgrouples/rogue/cc/ExecutableQuery.scala
@@ -234,7 +234,24 @@ case class InsertableQuery[MB, M <: MB, R, State](
     ex.async.insertMany(query, ts)
   }
 
+  /***
+    * replaces document with new one, matching by `_id` field. if such document does not exists and `upsert` == `true` new document is inserted
+    * @param t: a document
+    * @param upsert boolean parameter
+    * @param dba Database connection
+    */
+  def replaceOneAsync(t: R, upsert: Boolean = true)(implicit dba: MongoAsyncDatabase): Future[Unit] = ex.async.replaceOne(query, t, upsert)
+
   def insertOne(t: R)(implicit db: MongoDatabase): Unit = ex.sync.insertOne(query, t)
 
   def insertMany(ts: Seq[R])(implicit db: MongoDatabase): Unit = ex.sync.insertMany(query, ts)
+
+  /***
+    * replaces document with new one, matching by `_id` field. if such document does not exists and `upsert` == `true` new document is inserted
+    * @param t: a document
+    * @param upsert boolean parameter
+    * @param db Database connection
+    */
+  def replaceOne(t: R, upsert: Boolean = true)(implicit db: MongoDatabase): Unit = ex.sync.replaceOne(query, t, upsert)
+
 }

--- a/cc/src/main/scala/me/sgrouples/rogue/cc/MongoAsyncBsonJavaDriverAdapter.scala
+++ b/cc/src/main/scala/me/sgrouples/rogue/cc/MongoAsyncBsonJavaDriverAdapter.scala
@@ -379,4 +379,12 @@ class MongoAsyncBsonJavaDriverAdapter[MB](dbCollectionFactory: AsyncBsonDBCollec
     callback.future
   }
 
+  def replaceOne[M <: MB, R](query: Query[M, R, _], doc: BsonDocument, upsert: Boolean, writeConcern: WriteConcern)(implicit dba: MongoDatabase): Future[Unit] = {
+    val collection = dbCollectionFactory.getPrimaryDBCollection(query)
+    val callback = new UpdateResultCallback
+    val filter = new BsonDocument("_id", doc.get("_id"))
+    collection.replaceOne(filter, doc, new UpdateOptions().upsert(upsert), callback)
+    callback.future
+  }
+
 }

--- a/cc/src/main/scala/me/sgrouples/rogue/cc/MongoBsonJavaDriverAdapter.scala
+++ b/cc/src/main/scala/me/sgrouples/rogue/cc/MongoBsonJavaDriverAdapter.scala
@@ -283,4 +283,10 @@ class MongoBsonJavaDriverAdapter[MB](
     iter(cursor, initialState)
   }
 
+  def replaceOne[M <: MB, R](query: Query[M, R, _], doc: BsonDocument, upsert: Boolean, writeConcern: WriteConcern)(implicit db: MongoDatabase): Unit = {
+    val collection = dbCollectionFactory.getPrimaryDBCollection(query)
+    val filter = new BsonDocument("_id", doc.get("_id"))
+    collection.replaceOne(filter, doc, new UpdateOptions().upsert(upsert))
+  }
+
 }

--- a/cc/src/main/scala/me/sgrouples/rogue/cc/QueryExecutor.scala
+++ b/cc/src/main/scala/me/sgrouples/rogue/cc/QueryExecutor.scala
@@ -175,6 +175,10 @@ trait AsyncBsonQueryExecutor[MB] extends ReadWriteSerializers[MB] with Rogue {
     adapter.insertMany(query, docs, defaultWriteConcern)
   }
 
+  def replaceOne[M <: MB, R](query: Query[M, R, _], r: R, upsert: Boolean)(implicit dba: MongoAsyncDatabase): Future[Unit] = {
+    val s = writeSerializer[M, R](query.meta)
+    adapter.replaceOne(query, s.toDocument(r), upsert, defaultWriteConcern)
+  }
 }
 
 trait BsonQueryExecutor[MB] extends ReadWriteSerializers[MB] with Rogue {
@@ -433,6 +437,11 @@ trait BsonQueryExecutor[MB] extends ReadWriteSerializers[MB] with Rogue {
     val s = writeSerializer[M, R](query.meta)
     val docs = r.map { d => s.toDocument(d) }
     adapter.insertMany(query, docs, defaultWriteConcern)
+  }
+
+  def replaceOne[M <: MB, R](query: Query[M, R, _], r: R, upsert: Boolean)(implicit db: MongoDatabase): Unit = {
+    val s = writeSerializer[M, R](query.meta)
+    adapter.replaceOne(query, s.toDocument(r), upsert, defaultWriteConcern)
   }
 
 }

--- a/cc/src/test/scala/me/sgrouples/rogue/cc/EndToEndBsonAsyncSpec.scala
+++ b/cc/src/test/scala/me/sgrouples/rogue/cc/EndToEndBsonAsyncSpec.scala
@@ -346,5 +346,16 @@ class EndToEndBsonAsyncSpec extends FlatSpec with MustMatchers with ScalaFutures
       .futureValue.flatMap(_.lastClaim) mustBe Some(yetAnotherClaim)
 
   }
+
+  "ReplaceOne" should "work" in {
+    val v1 = OptValCC(maybes = Some("bef"), realString = "ore")
+    val v2 = v1.copy(maybes = None)
+    OptValCCR.insertOneAsync(v1).futureValue
+    OptValCCR.replaceOneAsync(v2).futureValue
+    val vr = OptValCCR.where(_.id eqs v1._id).getAsync().futureValue.get
+    vr.maybes mustBe None
+    vr.realString must ===("ore")
+  }
+
 }
 

--- a/cc/src/test/scala/me/sgrouples/rogue/cc/EndToEndBsonAsyncSpec.scala
+++ b/cc/src/test/scala/me/sgrouples/rogue/cc/EndToEndBsonAsyncSpec.scala
@@ -347,7 +347,7 @@ class EndToEndBsonAsyncSpec extends FlatSpec with MustMatchers with ScalaFutures
 
   }
 
-  "ReplaceOne" should "work" in {
+  "ReplaceOne" should "replace value" in {
     val v1 = OptValCC(maybes = Some("bef"), realString = "ore")
     val v2 = v1.copy(maybes = None)
     OptValCCR.insertOneAsync(v1).futureValue

--- a/cc/src/test/scala/me/sgrouples/rogue/cc/EndToEndBsonTest.scala
+++ b/cc/src/test/scala/me/sgrouples/rogue/cc/EndToEndBsonTest.scala
@@ -348,5 +348,16 @@ class EndToEndBsonTest extends JUnitMustMatchers {
     rs must_=== List("Real one", "real two")
   }
 
+  @Test
+  def replaceOneTest(): Unit = {
+    val v1 = OptValCC(maybes = Some("bef"), realString = "ore")
+    val v2 = v1.copy(maybes = None)
+    OptValCCR.insertOne(v1)
+    OptValCCR.replaceOne(v2)
+    val vr = OptValCCR.where(_.id eqs v1._id).get().get
+    vr.maybes must_=== None
+    vr.realString must_== "ore"
+  }
+
 }
 


### PR DESCRIPTION
It works in similar way as `save()` from lift record and old Mongo driver