### PR TITLE
Field helpers

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -8,6 +8,7 @@ lazy val core = (project in file("core")).settings(defaultSettings).dependsOn(fi
 lazy val indexchecker = (project in file("indexchecker")).settings(defaultSettings).dependsOn(core)
 lazy val lift = (project in file("lift")).settings(defaultSettings).dependsOn(field, indexchecker, core % "compile;test->test;runtime->runtime")
 //lazy val spindle = (project in file("spindle")).settings(defaultSettings).dependsOn(core)
+
 lazy val cc = (project in file("cc")).dependsOn(field, core).settings(defaultSettings)
 lazy val root = (project in file(".")).settings(defaultSettings).aggregate(field,core,index,indexchecker,lift,cc)
 

--- a/cc/src/main/scala/me/sgrouples/rogue/Fields.scala
+++ b/cc/src/main/scala/me/sgrouples/rogue/Fields.scala
@@ -14,6 +14,7 @@ import org.bson.types.ObjectId
 import org.bson.{ BsonDocument, BsonNull, BsonValue }
 import shapeless.ops.hlist.LiftAll
 import shapeless.syntax.SingletonOps
+import shapeless.tag.@@
 
 import scala.reflect.ClassTag
 
@@ -26,21 +27,44 @@ abstract class OCField[V, O](name: String, owner: O) extends CField[V, O](name, 
 class IntField[O](name: String, o: O) extends MCField[Int, O](name, o) {
   override def defaultValue = 0
 }
+
+class IntTaggedField[Tag, O](name: String, o: O) extends MCField[Int @@ Tag, O](name, o) {
+  override def defaultValue = tag[Tag][Int](0)
+}
+
 class LongField[O](name: String, o: O) extends MCField[Long, O](name, o) {
   override def defaultValue = 0L
 }
+
+class LongTaggedField[Tag, O](name: String, o: O) extends MCField[Long @@ Tag, O](name, o) {
+  override def defaultValue = tag[Tag][Long](0L)
+}
+
 class DoubleField[O](name: String, o: O) extends MCField[Double, O](name, o) {
   override def defaultValue = 0d
 }
 class StringField[O](name: String, o: O) extends MCField[String, O](name, o) {
   override def defaultValue = ""
 }
+
+class StringTaggedField[Tag, O](name: String, o: O) extends MCField[String @@ Tag, O](name, o) {
+  override def defaultValue = tag[Tag][String]("")
+}
+
 class ObjectIdField[O](name: String, o: O) extends MCField[ObjectId, O](name, o) {
   override def defaultValue = ObjectId.get()
 }
 
+class ObjectIdTaggedField[Tag, O](name: String, o: O) extends MCField[ObjectId @@ Tag, O](name, o) {
+  override def defaultValue = tag[Tag][ObjectId](ObjectId.get())
+}
+
 class UUIDIdField[O](name: String, o: O) extends MCField[UUID, O](name, o) {
   override def defaultValue = UUID.randomUUID()
+}
+
+class UUIDIdTaggedField[Tag, O](name: String, o: O) extends MCField[UUID @@ Tag, O](name, o) {
+  override def defaultValue = tag[Tag][UUID](UUID.randomUUID())
 }
 
 class LocalDateTimeField[O](name: String, o: O) extends MCField[LocalDateTime, O](name, o) {
@@ -123,11 +147,21 @@ class MapField[V, O](name: String, o: O) extends MCField[Map[String, V], O](name
 }
 
 class OptIntField[O](name: String, o: O) extends OCField[Int, O](name, o)
+class OptIntTaggedField[Tag, O](name: String, o: O) extends OCField[Int @@ Tag, O](name, o)
+
 class OptLongField[O](name: String, o: O) extends OCField[Long, O](name, o)
-class OptDoubleField[O](name: String, o: O) extends OCField[Double, O](name, o)
+class OptLongTaggedField[Tag, O](name: String, o: O) extends OCField[Long @@ Tag, O](name, o)
+
 class OptStringField[O](name: String, o: O) extends OCField[String, O](name, o)
+class OptStringTaggedField[Tag, O](name: String, o: O) extends OCField[String @@ Tag, O](name, o)
+
 class OptObjectIdField[O](name: String, o: O) extends OCField[ObjectId, O](name, o)
+class OptObjectIdTaggedField[Tag, O](name: String, o: O) extends OCField[ObjectId @@ Tag, O](name, o)
+
 class OptUUIDIdField[O](name: String, o: O) extends OCField[UUID, O](name, o)
+class OptUUIDIdTaggedField[Tag, O](name: String, o: O) extends OCField[UUID @@ Tag, O](name, o)
+
+class OptDoubleField[O](name: String, o: O) extends OCField[Double, O](name, o)
 class OptLocalDateTimeField[O](name: String, o: O) extends OCField[LocalDateTime, O](name, o)
 class OptInstantField[O](name: String, o: O) extends OCField[Instant, O](name, o)
 class OptBooleanField[O](name: String, o: O) extends OCField[Boolean, O](name, o)

--- a/cc/src/main/scala/me/sgrouples/rogue/cc/CcMeta.scala
+++ b/cc/src/main/scala/me/sgrouples/rogue/cc/CcMeta.scala
@@ -83,13 +83,13 @@ class RCcMeta[T](collName: String)(implicit f: BsonFormat[T]) extends CcMeta[T] 
 }
 
 /**
-  * Rogue Case Class Meta Extended, awesome name!
-  *
-  * @param collName
-  * @param formats
-  * @tparam RecordType
-  * @tparam OwnerType
-  */
+ * Rogue Case Class Meta Extended, awesome name!
+ *
+ * @param collName
+ * @param formats
+ * @tparam RecordType
+ * @tparam OwnerType
+ */
 
 class RCcMetaExt[RecordType, OwnerType <: RCcMeta[RecordType]](collName: String)(implicit formats: BsonFormat[RecordType])
     extends RCcMeta[RecordType](collName)(formats)

--- a/cc/src/main/scala/me/sgrouples/rogue/cc/CcMeta.scala
+++ b/cc/src/main/scala/me/sgrouples/rogue/cc/CcMeta.scala
@@ -81,3 +81,23 @@ class RCcMeta[T](collName: String)(implicit f: BsonFormat[T]) extends CcMeta[T] 
   def createIndex(indexTuples: Seq[(String, Int)])(implicit dbs: MongoDatabase): String = createIndex(indexTuples, new IndexOptions())
 
 }
+
+/**
+  * Rogue Case Class Meta Extended, awesome name!
+  *
+  * @param collName
+  * @param formats
+  * @tparam RecordType
+  * @tparam OwnerType
+  */
+
+class RCcMetaExt[RecordType, OwnerType <: RCcMeta[RecordType]](collName: String)(implicit formats: BsonFormat[RecordType])
+    extends RCcMeta[RecordType](collName)(formats)
+    with QueryFieldHelpers[OwnerType] { requires: OwnerType =>
+
+  def this(
+    namingStrategy: NamingStrategy = LowerCase
+  )(implicit formats: BsonFormat[RecordType], classTag: ClassTag[RecordType]) {
+    this(namingStrategy[RecordType])(formats)
+  }
+}

--- a/cc/src/main/scala/me/sgrouples/rogue/cc/QueryFieldHelpers.scala
+++ b/cc/src/main/scala/me/sgrouples/rogue/cc/QueryFieldHelpers.scala
@@ -100,13 +100,13 @@ trait QueryFieldHelpers[Meta] extends {
     Its complicated, I know, meta programming usually is... But Miles Sabin's @@ is awesome, don't you think?
    */
 
-  private def named[T](func: String => T): T @@ Marker = {
+  protected def named[T](func: String => T): T @@ Marker = {
     if (names.isEmpty) resolve()
     val name = names(nextNameId)
     tag[Marker][T](func(name))
   }
 
-  private def named[T](name: String)(func: String => T): T @@ Marker = {
+  protected def named[T](name: String)(func: String => T): T @@ Marker = {
     if (names.isEmpty) resolve()
     names += nextNameId -> name
     tag[Marker][T](func(name))

--- a/cc/src/main/scala/me/sgrouples/rogue/cc/QueryFieldHelpers.scala
+++ b/cc/src/main/scala/me/sgrouples/rogue/cc/QueryFieldHelpers.scala
@@ -15,15 +15,15 @@ private[cc] sealed trait Marker
 trait QueryFieldHelpers[Meta] extends {
   requires: Meta =>
 
-  private val names: mutable.Map[Int, String] = mutable.Map.empty
+  private[this] val names: mutable.Map[Int, String] = mutable.Map.empty
 
-  private val fields: mutable.Map[String, io.fsq.field.Field[_, _]] = mutable.Map.empty
+  private[this] val fields: mutable.Map[String, io.fsq.field.Field[_, _]] = mutable.Map.empty
 
-  private val nameId = new AtomicInteger(-1)
+  private[this] val nameId = new AtomicInteger(-1)
 
   // This one is hacky, we need to find the type tag from Java's getClass method...
 
-  private implicit val typeTag: TypeTag[Meta] = {
+  private[this] implicit val typeTag: TypeTag[Meta] = {
 
     val mirror = runtimeMirror(getClass.getClassLoader)
     val sym = mirror.classSymbol(getClass)
@@ -36,9 +36,9 @@ trait QueryFieldHelpers[Meta] extends {
     })
   }
 
-  private def nextNameId = nameId.incrementAndGet()
+  private[this] def nextNameId = nameId.incrementAndGet()
 
-  private def resolve(): Unit = {
+  private[this] def resolve(): Unit = {
 
     /*
       The idea of automatic name resolution is taken from Scala's Enumeration,
@@ -104,10 +104,11 @@ trait QueryFieldHelpers[Meta] extends {
 
   protected def named[T <: io.fsq.field.Field[_, _]](func: String => T): T @@ Marker = {
     if (names.isEmpty) resolve()
-    // so yeah, this version doesn't support auto name resolution for inner meta classes...
+
     val name = names.getOrElse(nextNameId, throw new IllegalStateException(
       "Something went wrong: couldn't auto-resolve field names, pleace contact author at mikolaj@sgrouples.com"
     ))
+
     val field = func(name)
     if (fields.contains(name)) throw new IllegalArgumentException(s"Field with name $name is already defined")
     fields += (name -> field)

--- a/cc/src/main/scala/me/sgrouples/rogue/cc/QueryFieldHelpers.scala
+++ b/cc/src/main/scala/me/sgrouples/rogue/cc/QueryFieldHelpers.scala
@@ -105,7 +105,9 @@ trait QueryFieldHelpers[Meta] extends {
   protected def named[T <: io.fsq.field.Field[_, _]](func: String => T): T @@ Marker = {
     if (names.isEmpty) resolve()
     // so yeah, this version doesn't support auto name resolution for inner meta classes...
-    val name = names.getOrElse(nextNameId, throw new IllegalStateException("Couldn't auto-resolve field names, make sure that meta class is not an inner class..."))
+    val name = names.getOrElse(nextNameId, throw new IllegalStateException(
+      "Something went wrong: couldn't auto-resolve field names, pleace contact author at mikolaj@sgrouples.com"
+    ))
     val field = func(name)
     if (fields.contains(name)) throw new IllegalArgumentException(s"Field with name $name is already defined")
     fields += (name -> field)

--- a/cc/src/main/scala/me/sgrouples/rogue/cc/QueryFieldHelpers.scala
+++ b/cc/src/main/scala/me/sgrouples/rogue/cc/QueryFieldHelpers.scala
@@ -92,6 +92,14 @@ trait QueryFieldHelpers[Meta] extends {
 
   }
 
+  /*
+    This weird tagging by Marker trait is here because we need to filter out fields declared
+    directly by calling constructors (like before we had this helper): `val name = new StringField("name", this)`
+    They are both vals and do return a type assignable from `io.fsq.field.Field[_, _]`, so to know that those
+    are not to be counted for name resolution, we must tag the right ones with a marking trait.
+    Its complicated, I know, meta programming usually is... But Miles Sabin's @@ is awesome, don't you think?
+   */
+
   private def named[T](func: String => T): T @@ Marker = {
     if (names.isEmpty) resolve()
     val name = names(nextNameId)

--- a/cc/src/main/scala/me/sgrouples/rogue/cc/QueryFieldHelpers.scala
+++ b/cc/src/main/scala/me/sgrouples/rogue/cc/QueryFieldHelpers.scala
@@ -1,0 +1,201 @@
+package me.sgrouples.rogue.cc
+
+import java.util.concurrent.atomic.AtomicInteger
+
+import me.sgrouples.rogue._
+
+import scala.reflect.{ ClassTag, api }
+import scala.collection.mutable
+import scala.reflect.runtime.universe._
+
+object Foo extends Enumeration
+
+trait QueryFieldHelpers[Meta] extends {
+  requires: Meta =>
+
+  private val names: mutable.Map[Int, String] = mutable.Map.empty
+
+  private val nameId = new AtomicInteger(-1)
+
+  // This one is hacky, we need to find the type tag from Java's getClass method...
+
+  private implicit val typeTag: TypeTag[Meta] = {
+
+    val mirror = runtimeMirror(getClass.getClassLoader)
+    val sym = mirror.staticClass(getClass.getName)
+    val tpe = sym.selfType
+
+    TypeTag(mirror, new api.TypeCreator {
+      def apply[U <: api.Universe with Singleton](m: api.Mirror[U]): U#Type =
+        if (m eq mirror) tpe.asInstanceOf[U#Type]
+        else throw new IllegalArgumentException(s"Type tag defined in $mirror cannot be migrated to other mirrors.")
+    })
+  }
+
+  private def nextNameId = nameId.incrementAndGet()
+
+  private def resolve(): Unit = {
+
+    /*
+      The idea of automatic name resolution is taken from Scala's Enumeration,
+      but imlemented without falling back to Java's reflection api.
+     */
+
+    val decode: Symbol => String = _.name.decodedName.toString.trim
+
+    // we are looking for vals accessible from io.fsq.field.Field[_, _]
+
+    val returnsRogueField: Symbol => Boolean = {
+      _.asMethod.returnType <:< typeOf[io.fsq.field.Field[_, _]]
+    }
+
+    val valueGettersOnly: Symbol => Boolean = {
+      x => x.isMethod && !x.isSynthetic && returnsRogueField(x)
+    }
+
+    val valueGetters: Map[String, MethodSymbol] = {
+      typeOf[Meta].baseClasses.foldLeft(Map.empty[String, MethodSymbol]) {
+        case (acc, baseClass) =>
+          acc ++ appliedType(baseClass).decls.filter(valueGettersOnly).map {
+            getter => decode(getter) -> getter.asMethod
+          }(scala.collection.breakOut): Map[String, MethodSymbol]
+      }
+    }
+
+    /*
+      We need to have those values in the order of trait linearization,
+      but the api doesn't guarantee order for synthetic members, so we just need
+      to iterate over declared vals but match them with synthetic getters, easy!
+    */
+
+    val valuesOnly: Symbol => Boolean = {
+      x => !x.isMethod && valueGetters.contains(decode(x))
+    }
+
+    /*
+      This reverse here is because traits are initialized in oposite order than declared...
+     */
+
+    val values = typeOf[Meta].baseClasses.reverse.flatMap {
+      baseClass => appliedType(baseClass).decls.sorted.filter(valuesOnly)
+    }.map(decode)
+
+    // name map in order of trait linearization
+
+    names ++= values.zipWithIndex.map(_.swap)
+
+  }
+
+  private def named[T](func: String => T): T = {
+    if (names.isEmpty) resolve()
+    val name = names(nextNameId)
+    func(name)
+  }
+
+  private def named[T](name: String)(func: String => T): T = {
+    if (names.isEmpty) resolve()
+    names += nextNameId -> name
+    func(name)
+  }
+
+  protected def IntField: IntField[Meta] = named(new IntField[Meta](_, this))
+  protected def IntField(name: String): IntField[Meta] = named(name)(new IntField[Meta](_, this))
+
+  protected def OptIntField: OptIntField[Meta] = named(new OptIntField[Meta](_, this))
+  protected def OptIntField(name: String): OptIntField[Meta] = named(name)(new OptIntField[Meta](_, this))
+
+  protected def StringField: StringField[Meta] = named(new StringField[Meta](_, this))
+  protected def StringField(name: String): StringField[Meta] = named(name)(new StringField[Meta](_, this))
+
+  protected def OptStringField: OptStringField[Meta] = named(new OptStringField[Meta](_, this))
+  protected def OptStringField(name: String): OptStringField[Meta] = named(name)(new OptStringField[Meta](_, this))
+
+  protected def LongField: LongField[Meta] = named(new LongField[Meta](_, this))
+  protected def LongField(name: String): LongField[Meta] = named(name)(new LongField[Meta](_, this))
+
+  protected def OptLongField: OptLongField[Meta] = named(new OptLongField[Meta](_, this))
+  protected def OptLongField(name: String): OptLongField[Meta] = named(name)(new OptLongField[Meta](_, this))
+
+  protected def DoubleField: DoubleField[Meta] = named(new DoubleField[Meta](_, this))
+  protected def DoubleField(name: String): DoubleField[Meta] = named(name)(new DoubleField[Meta](_, this))
+
+  protected def OptDoubleField: OptDoubleField[Meta] = named(new OptDoubleField[Meta](_, this))
+  protected def OptDoubleField(name: String): OptDoubleField[Meta] = named(name)(new OptDoubleField[Meta](_, this))
+
+  protected def ObjectIdField: ObjectIdField[Meta] = named(new ObjectIdField[Meta](_, this))
+  protected def ObjectIdField(name: String): ObjectIdField[Meta] = named(name)(new ObjectIdField[Meta](_, this))
+
+  protected def OptObjectIdField: OptObjectIdField[Meta] = named(new OptObjectIdField[Meta](_, this))
+  protected def OptObjectIdField(name: String): OptObjectIdField[Meta] = named(name)(new OptObjectIdField[Meta](_, this))
+
+  protected def UUIDField: UUIDIdField[Meta] = named(new UUIDIdField[Meta](_, this))
+  protected def UUIDField(name: String): UUIDIdField[Meta] = named(name)(new UUIDIdField[Meta](_, this))
+
+  protected def OptUUIDField: OptUUIDIdField[Meta] = named(new OptUUIDIdField[Meta](_, this))
+  protected def OptUUIDField(name: String): OptUUIDIdField[Meta] = named(name)(new OptUUIDIdField[Meta](_, this))
+
+  protected def LocalDateTimeField: LocalDateTimeField[Meta] = named(new LocalDateTimeField[Meta](_, this))
+  protected def LocalDateTimeField(name: String): LocalDateTimeField[Meta] = named(name)(new LocalDateTimeField[Meta](_, this))
+
+  protected def OptLocalDateTimeField: OptLocalDateTimeField[Meta] = named(new OptLocalDateTimeField[Meta](_, this))
+  protected def OptLocalDateTimeField(name: String): OptLocalDateTimeField[Meta] = named(name)(new OptLocalDateTimeField[Meta](_, this))
+
+  protected def InstantField: InstantField[Meta] = named(new InstantField[Meta](_, this))
+  protected def InstantField(name: String): InstantField[Meta] = named(name)(new InstantField[Meta](_, this))
+
+  protected def OptInstantField: OptInstantField[Meta] = named(new OptInstantField[Meta](_, this))
+  protected def OptInstantField(name: String): OptInstantField[Meta] = named(name)(new OptInstantField[Meta](_, this))
+
+  protected def BooleanField: BooleanField[Meta] = named(new BooleanField[Meta](_, this))
+  protected def BooleanField(name: String): BooleanField[Meta] = named(name)(new BooleanField[Meta](_, this))
+
+  protected def OptBooleanField: OptBooleanField[Meta] = named(new OptBooleanField[Meta](_, this))
+  protected def OptBooleanField(name: String): OptBooleanField[Meta] = named(name)(new OptBooleanField[Meta](_, this))
+
+  protected def EnumField[E <: Enumeration](implicit e: E): EnumField[E, Meta] = named(new EnumField[E, Meta](_, this)(e))
+  protected def EnumField[E <: Enumeration](name: String)(implicit e: E): EnumField[E, Meta] = named(name)(new EnumField[E, Meta](_, this)(e))
+
+  protected def OptEnumField[E <: Enumeration](implicit e: E): OptEnumField[E, Meta] = named(new OptEnumField[E, Meta](_, this)(e))
+  protected def OptEnumField[E <: Enumeration](name: String)(implicit e: E): OptEnumField[E, Meta] = named(name)(new OptEnumField[E, Meta](_, this)(e))
+
+  protected def EnumIdField[E <: Enumeration](implicit e: E): EnumIdField[E, Meta] = named(new EnumIdField[E, Meta](_, this)(e))
+  protected def EnumIdField[E <: Enumeration](name: String)(implicit e: E): EnumIdField[E, Meta] = named(name)(new EnumIdField[E, Meta](_, this)(e))
+
+  protected def OptEnumIdField[E <: Enumeration](implicit e: E): OptEnumIdField[E, Meta] = named(new OptEnumIdField[E, Meta](_, this)(e))
+  protected def OptEnumIdField[E <: Enumeration](name: String)(implicit e: E): OptEnumIdField[E, Meta] = named(name)(new OptEnumIdField[E, Meta](_, this)(e))
+
+  protected def ListField[V]: ListField[V, Meta] = named(new ListField[V, Meta](_, this))
+  protected def ListField[V](name: String): ListField[V, Meta] = named(name)(new ListField[V, Meta](_, this))
+
+  protected def OptListField[V]: OptListField[V, Meta] = named(new OptListField[V, Meta](_, this))
+  protected def OptListField[V](name: String): OptListField[V, Meta] = named(name)(new OptListField[V, Meta](_, this))
+
+  protected def ArrayField[V: ClassTag]: ArrayField[V, Meta] = named(new ArrayField[V, Meta](_, this))
+  protected def ArrayField[V: ClassTag](name: String): ArrayField[V, Meta] = named(name)(new ArrayField[V, Meta](_, this))
+
+  protected def OptArrayField[V: ClassTag]: OptArrayField[V, Meta] = named(new OptArrayField[V, Meta](_, this))
+  protected def OptArrayField[V: ClassTag](name: String): OptArrayField[V, Meta] = named(name)(new OptArrayField[V, Meta](_, this))
+
+  protected def ClassField[C, MC <: CcMeta[C]](mc: MC): CClassField[C, MC, Meta] = named(new CClassField[C, MC, Meta](_, mc, this))
+  protected def ClassField[C, MC <: CcMeta[C]](name: String, mc: MC): CClassField[C, MC, Meta] = named(name)(new CClassField[C, MC, Meta](_, mc, this))
+
+  protected def OptClassField[C, MC <: CcMeta[C]](mc: MC): OptCClassField[C, MC, Meta] = named(new OptCClassField[C, MC, Meta](_, mc, this))
+  protected def OptClassField[C, MC <: CcMeta[C]](name: String, mc: MC): OptCClassField[C, MC, Meta] = named(name)(new OptCClassField[C, MC, Meta](_, mc, this))
+
+  protected def ClassRequiredField[C, MC <: CcMeta[C]](mc: MC, default: C): CClassRequiredField[C, MC, Meta] = named(new CClassRequiredField(_, mc, default, this))
+  protected def ClassRequiredField[C, MC <: CcMeta[C]](name: String, mc: MC, default: C): CClassRequiredField[C, MC, Meta] = named(name)(new CClassRequiredField(_, mc, default, this))
+
+  protected def ClassListField[C: ClassTag, MC <: CcMeta[C]](mc: MC): CClassListField[C, MC, Meta] = named(new CClassListField[C, MC, Meta](_, mc, this))
+  protected def ClassListField[C: ClassTag, MC <: CcMeta[C]](name: String, mc: MC): CClassListField[C, MC, Meta] = named(name)(new CClassListField[C, MC, Meta](_, mc, this))
+  // TODO: OptClassListField?
+
+  protected def ClassArrayField[C: ClassTag, MC <: CcMeta[C]](mc: MC): CClassArrayField[C, MC, Meta] = named(new CClassArrayField[C, MC, Meta](_, mc, this))
+  protected def ClassArrayField[C: ClassTag, MC <: CcMeta[C]](name: String, mc: MC): CClassArrayField[C, MC, Meta] = named(name)(new CClassArrayField[C, MC, Meta](_, mc, this))
+  // TODO: OptClassArrayField?
+
+  protected def MapField[V]: MapField[V, Meta] = named(new MapField[V, Meta](_, this))
+  protected def MapField[V](name: String): MapField[V, Meta] = named(name)(new MapField[V, Meta](_, this))
+
+  protected def OptMapField[V]: OptMapField[V, Meta] = named(new OptMapField[V, Meta](_, this))
+  protected def OptMapField[V](name: String): OptMapField[V, Meta] = named(name)(new OptMapField[V, Meta](_, this))
+}

--- a/cc/src/main/scala/me/sgrouples/rogue/cc/QueryFieldHelpers.scala
+++ b/cc/src/main/scala/me/sgrouples/rogue/cc/QueryFieldHelpers.scala
@@ -110,17 +110,35 @@ trait QueryFieldHelpers[Meta] extends {
   protected def OptIntField: OptIntField[Meta] @@ Marker = named(new OptIntField[Meta](_, this))
   protected def OptIntField(name: String): OptIntField[Meta] @@ Marker = named(name)(new OptIntField[Meta](_, this))
 
+  protected def IntTaggedField[Tag]: IntTaggedField[Tag, Meta] @@ Marker = named(new IntTaggedField[Tag, Meta](_, this))
+  protected def IntTaggedField[Tag](name: String): IntTaggedField[Tag, Meta] @@ Marker = named(name)(new IntTaggedField[Tag, Meta](_, this))
+
+  protected def OptIntTaggedField[Tag]: OptIntTaggedField[Tag, Meta] @@ Marker = named(new OptIntTaggedField[Tag, Meta](_, this))
+  protected def OptIntTaggedField[Tag](name: String): OptIntTaggedField[Tag, Meta] @@ Marker = named(name)(new OptIntTaggedField[Tag, Meta](_, this))
+
   protected def StringField: StringField[Meta] @@ Marker = named(new StringField[Meta](_, this))
   protected def StringField(name: String): StringField[Meta] @@ Marker = named(name)(new StringField[Meta](_, this))
 
   protected def OptStringField: OptStringField[Meta] @@ Marker = named(new OptStringField[Meta](_, this))
   protected def OptStringField(name: String): OptStringField[Meta] @@ Marker = named(name)(new OptStringField[Meta](_, this))
 
+  protected def StringTaggedField[Tag]: StringTaggedField[Tag, Meta] @@ Marker = named(new StringTaggedField[Tag, Meta](_, this))
+  protected def StringTaggedField[Tag](name: String): StringTaggedField[Tag, Meta] @@ Marker = named(name)(new StringTaggedField[Tag, Meta](_, this))
+
+  protected def OptStringTaggedField[Tag]: OptStringTaggedField[Tag, Meta] @@ Marker = named(new OptStringTaggedField[Tag, Meta](_, this))
+  protected def OptStringTaggedField[Tag](name: String): OptStringTaggedField[Tag, Meta] @@ Marker = named(name)(new OptStringTaggedField[Tag, Meta](_, this))
+
   protected def LongField: LongField[Meta] @@ Marker = named(new LongField[Meta](_, this))
   protected def LongField(name: String): LongField[Meta] @@ Marker = named(name)(new LongField[Meta](_, this))
 
   protected def OptLongField: OptLongField[Meta] @@ Marker = named(new OptLongField[Meta](_, this))
   protected def OptLongField(name: String): OptLongField[Meta] @@ Marker = named(name)(new OptLongField[Meta](_, this))
+
+  protected def LongTaggedField[Tag]: LongTaggedField[Tag, Meta] @@ Marker = named(new LongTaggedField[Tag, Meta](_, this))
+  protected def LongTaggedField[Tag](name: String): LongTaggedField[Tag, Meta] @@ Marker = named(name)(new LongTaggedField[Tag, Meta](_, this))
+
+  protected def OptLongTaggedField[Tag]: OptLongTaggedField[Tag, Meta] @@ Marker = named(new OptLongTaggedField[Tag, Meta](_, this))
+  protected def OptLongTaggedField[Tag](name: String): OptLongTaggedField[Tag, Meta] @@ Marker = named(name)(new OptLongTaggedField[Tag, Meta](_, this))
 
   protected def DoubleField: DoubleField[Meta] @@ Marker = named(new DoubleField[Meta](_, this))
   protected def DoubleField(name: String): DoubleField[Meta] @@ Marker = named(name)(new DoubleField[Meta](_, this))
@@ -134,11 +152,23 @@ trait QueryFieldHelpers[Meta] extends {
   protected def OptObjectIdField: OptObjectIdField[Meta] @@ Marker = named(new OptObjectIdField[Meta](_, this))
   protected def OptObjectIdField(name: String): OptObjectIdField[Meta] @@ Marker = named(name)(new OptObjectIdField[Meta](_, this))
 
-  protected def UUIDField: UUIDIdField[Meta] @@ Marker = named(new UUIDIdField[Meta](_, this))
-  protected def UUIDField(name: String): UUIDIdField[Meta] @@ Marker = named(name)(new UUIDIdField[Meta](_, this))
+  protected def ObjectIdTaggedField[Tag]: ObjectIdTaggedField[Tag, Meta] @@ Marker = named(new ObjectIdTaggedField[Tag, Meta](_, this))
+  protected def ObjectIdTaggedField[Tag](name: String): ObjectIdTaggedField[Tag, Meta] @@ Marker = named(name)(new ObjectIdTaggedField[Tag, Meta](_, this))
 
-  protected def OptUUIDField: OptUUIDIdField[Meta] @@ Marker = named(new OptUUIDIdField[Meta](_, this))
-  protected def OptUUIDField(name: String): OptUUIDIdField[Meta] @@ Marker = named(name)(new OptUUIDIdField[Meta](_, this))
+  protected def OptObjectIdTaggedField[Tag]: OptObjectIdTaggedField[Tag, Meta] @@ Marker = named(new OptObjectIdTaggedField[Tag, Meta](_, this))
+  protected def OptObjectIdTaggedField[Tag](name: String): OptObjectIdTaggedField[Tag, Meta] @@ Marker = named(name)(new OptObjectIdTaggedField[Tag, Meta](_, this))
+
+  protected def UUIdField: UUIDIdField[Meta] @@ Marker = named(new UUIDIdField[Meta](_, this))
+  protected def UUIdField(name: String): UUIDIdField[Meta] @@ Marker = named(name)(new UUIDIdField[Meta](_, this))
+
+  protected def OptUUIdField: OptUUIDIdField[Meta] @@ Marker = named(new OptUUIDIdField[Meta](_, this))
+  protected def OptUUIdField(name: String): OptUUIDIdField[Meta] @@ Marker = named(name)(new OptUUIDIdField[Meta](_, this))
+
+  protected def UUIdTaggedField[Tag]: UUIDIdTaggedField[Tag, Meta] @@ Marker = named(new UUIDIdTaggedField[Tag, Meta](_, this))
+  protected def UUIdTaggedField[Tag](name: String): UUIDIdTaggedField[Tag, Meta] @@ Marker = named(name)(new UUIDIdTaggedField[Tag, Meta](_, this))
+
+  protected def OptUUIdTaggedField[Tag]: OptUUIDIdTaggedField[Tag, Meta] @@ Marker = named(new OptUUIDIdTaggedField[Tag, Meta](_, this))
+  protected def OptUUIdTaggedField[Tag](name: String): OptUUIDIdTaggedField[Tag, Meta] @@ Marker = named(name)(new OptUUIDIdTaggedField[Tag, Meta](_, this))
 
   protected def LocalDateTimeField: LocalDateTimeField[Meta] @@ Marker = named(new LocalDateTimeField[Meta](_, this))
   protected def LocalDateTimeField(name: String): LocalDateTimeField[Meta] @@ Marker = named(name)(new LocalDateTimeField[Meta](_, this))

--- a/cc/src/main/scala/me/sgrouples/rogue/cc/QueryFieldHelpers.scala
+++ b/cc/src/main/scala/me/sgrouples/rogue/cc/QueryFieldHelpers.scala
@@ -8,8 +8,6 @@ import scala.reflect.{ ClassTag, api }
 import scala.collection.mutable
 import scala.reflect.runtime.universe._
 
-object Foo extends Enumeration
-
 trait QueryFieldHelpers[Meta] extends {
   requires: Meta =>
 

--- a/cc/src/test/scala/TestModels.scala
+++ b/cc/src/test/scala/TestModels.scala
@@ -89,43 +89,50 @@ object Metas {
 
   implicit val evClaimStatus = ClaimStatus
 
-  object VenueClaimBsonR extends RCcMeta[VenueClaimBson]("_") {
-    val uid = new LongField("uid", this)
-    val status = new EnumField[ClaimStatus.type, VenueClaimBsonR.type]("status", this)
-    val source = new OptCClassField[SourceBson, SourceBsonR.type, VenueClaimBsonR.type]("source", SourceBsonR, this)
-    val date = new LocalDateTimeField("date", this)
+  class VenueClaimBsonRMeta extends RCcMeta[VenueClaimBson]("_") with QueryFieldHelpers[VenueClaimBsonRMeta] {
+    val uid = LongField("uid")
+    val status = EnumField[ClaimStatus.type]("status")
+    val source = OptClassField[SourceBson, SourceBsonR.type]("source", SourceBsonR)
+    val date = LocalDateTimeField("date")
   }
+
+  val VenueClaimBsonR = new VenueClaimBsonRMeta
 
   implicit val evVenueStatus = VenueStatus
 
-  object VenueR extends RCcMeta[Venue](PluralLowerCase) {
-    val id = new ObjectIdField("_id", this)
-    val mayor = new LongField("mayor", this)
-    val venuename = new StringField("venuename", this)
-    val closed = new BooleanField("closed", this)
-    val status = new EnumField[VenueStatus.type, VenueR.type]("status", this)
-    val mayor_count = new LongField("mayor_count", this)
-    val legacyid = new LongField("legId", this)
-    val userid = new LongField("userId", this)
-    val tags = new ListField[String, VenueR.type]("tags", this)
-    val claims = new CClassListField[VenueClaimBson, VenueClaimBsonR.type, VenueR.type]("claims", VenueClaimBsonR, this)
-    val lastClaim = new OptCClassField[VenueClaimBson, VenueClaimBsonR.type, VenueR.type]("lastClaim", VenueClaimBsonR, this)
-    val firstClaim = new CClassRequiredField[VenueClaimBson, VenueClaimBsonR.type, VenueR.type](
-      "firstClaim", VenueClaimBsonR, VenueClaimBson.default, this
-    )
-    val last_updated = new LocalDateTimeField("last_updated", this)
-    val popularity = new ListField[Long, VenueR.type]("popularity", this)
-    val categories = new ListField[ObjectId, VenueR.type]("categories", this)
+  class VenueRMeta extends RCcMeta[Venue](PluralLowerCase) with QueryFieldHelpers[VenueRMeta] {
+
+    val id = ObjectIdField("_id")
+    val mayor = LongField
+    val venuename = StringField
+    val closed = BooleanField
+    val status = EnumField[VenueStatus.type]
+    val mayor_count = LongField
+    val legacyid = LongField("legId")
+    val userid = LongField("userId")
+    val tags = ListField[String]
+
+    val claims = ClassListField[VenueClaimBson, VenueClaimBsonRMeta](VenueClaimBsonR)
+    val lastClaim = OptClassField[VenueClaimBson, VenueClaimBsonRMeta](VenueClaimBsonR)
+    val firstClaim = ClassRequiredField(VenueClaimBsonR, VenueClaimBson.default)
+
+    val last_updated = LocalDateTimeField
+    val popularity = ListField[Long]
+    val categories = ListField[ObjectId]
   }
+
+  val VenueR = new VenueRMeta
 
   implicit val evRejReason = RejectReason
 
-  object VenueClaimR extends RCcMeta[VenueClaim]("venueclaims") {
-    val venueid = new ObjectIdField("vid", this)
-    val status = new EnumField[ClaimStatus.type, VenueClaimR.type]("status", this)
-    val reason = new OptEnumField[RejectReason.type, VenueClaimR.type]("reason", this)
-    val userId = new LongField("uid", this)
+  class VenueClaimRMeta extends RCcMeta[VenueClaim]("venueclaims") with QueryFieldHelpers[VenueClaimRMeta] {
+    val venueid = ObjectIdField("vid")
+    val status = EnumField[ClaimStatus.type]
+    val reason = OptEnumField[RejectReason.type]
+    val userId = LongField("uid")
   }
+
+  val VenueClaimR = new VenueClaimRMeta
 
   object TipR extends RCcMeta[Tip]("tips") {
     val id = new ObjectIdField("_id", this)

--- a/cc/src/test/scala/TestModels.scala
+++ b/cc/src/test/scala/TestModels.scala
@@ -110,7 +110,7 @@ object Metas {
 
   implicit val evVenueStatus = VenueStatus
 
-  class VenueRMeta extends RCcMeta[Venue](PluralLowerCase) with QueryFieldHelpers[VenueRMeta] {
+  class VenueRMeta extends RCcMetaExt[Venue, VenueRMeta](PluralLowerCase) {
 
     val id = ObjectIdTaggedField[Venue]("_id")
     val mayor = LongField
@@ -119,7 +119,7 @@ object Metas {
     val status = EnumField[VenueStatus.type]
     val mayor_count = LongField
     val legacyid = LongField("legId")
-    val userid = LongField("userId")
+    val userId = LongField
     val tags = ListField[String]
 
     val claims = ClassListField[VenueClaimBson, VenueClaimBsonRMeta](VenueClaimBsonR)

--- a/cc/src/test/scala/me/sgrouples/rogue/cc/EndToEndBsonAsyncSpec.scala
+++ b/cc/src/test/scala/me/sgrouples/rogue/cc/EndToEndBsonAsyncSpec.scala
@@ -10,6 +10,7 @@ import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{ BeforeAndAfterEach, FlatSpec, MustMatchers }
 
 import scala.concurrent.duration._
+import shapeless.tag
 
 class EndToEndBsonAsyncSpec extends FlatSpec with MustMatchers with ScalaFutures with BeforeAndAfterEach {
   import Metas._
@@ -19,7 +20,7 @@ class EndToEndBsonAsyncSpec extends FlatSpec with MustMatchers with ScalaFutures
   val lastClaim = VenueClaimBson(uid = 5678L, status = ClaimStatus.approved)
 
   def baseTestVenue(): Venue = Venue(
-    _id = new ObjectId(),
+    _id = tag[Venue][ObjectId](new ObjectId()),
     legId = 123L,
     userId = 456L,
     venuename = "test venue",
@@ -39,7 +40,7 @@ class EndToEndBsonAsyncSpec extends FlatSpec with MustMatchers with ScalaFutures
   )
 
   def baseTestVenueClaim(vid: ObjectId): VenueClaim = {
-    VenueClaim(new ObjectId(), vid, 123L, ClaimStatus.approved)
+    VenueClaim(tag[VenueClaim][ObjectId](new ObjectId()), vid, 123L, ClaimStatus.approved)
   }
 
   def baseTestTip(): Tip = {

--- a/cc/src/test/scala/me/sgrouples/rogue/cc/EndToEndBsonAsyncSpec.scala
+++ b/cc/src/test/scala/me/sgrouples/rogue/cc/EndToEndBsonAsyncSpec.scala
@@ -122,11 +122,11 @@ class EndToEndBsonAsyncSpec extends FlatSpec with MustMatchers with ScalaFutures
 
     base.select(_.legacyid).fetchAsync().futureValue mustBe List(v.legId)
 
-    base.select(_.legacyid, _.userid).fetchAsync().futureValue mustBe List((v.legId, v.userId))
-    base.select(_.legacyid, _.userid, _.mayor).fetchAsync().futureValue mustBe List((v.legId, v.userId, v.mayor))
-    base.select(_.legacyid, _.userid, _.mayor, _.mayor_count).fetchAsync().futureValue mustBe List((v.legId, v.userId, v.mayor, v.mayor_count))
-    base.select(_.legacyid, _.userid, _.mayor, _.mayor_count, _.closed).fetchAsync().futureValue mustBe List((v.legId, v.userId, v.mayor, v.mayor_count, v.closed))
-    base.select(_.legacyid, _.userid, _.mayor, _.mayor_count, _.closed, _.tags).fetchAsync().futureValue mustBe List((v.legId, v.userId, v.mayor, v.mayor_count, v.closed, v.tags))
+    base.select(_.legacyid, _.userId).fetchAsync().futureValue mustBe List((v.legId, v.userId))
+    base.select(_.legacyid, _.userId, _.mayor).fetchAsync().futureValue mustBe List((v.legId, v.userId, v.mayor))
+    base.select(_.legacyid, _.userId, _.mayor, _.mayor_count).fetchAsync().futureValue mustBe List((v.legId, v.userId, v.mayor, v.mayor_count))
+    base.select(_.legacyid, _.userId, _.mayor, _.mayor_count, _.closed).fetchAsync().futureValue mustBe List((v.legId, v.userId, v.mayor, v.mayor_count, v.closed))
+    base.select(_.legacyid, _.userId, _.mayor, _.mayor_count, _.closed, _.tags).fetchAsync().futureValue mustBe List((v.legId, v.userId, v.mayor, v.mayor_count, v.closed, v.tags))
 
   }
 
@@ -142,11 +142,11 @@ class EndToEndBsonAsyncSpec extends FlatSpec with MustMatchers with ScalaFutures
 
     val base = VenueR.where(_.id eqs v._id)
     base.selectCase(_.legacyid, V1).fetchAsync().futureValue mustBe List(V1(v.legId))
-    base.selectCase(_.legacyid, _.userid, V2).fetchAsync().futureValue mustBe List(V2(v.legId, v.userId))
-    base.selectCase(_.legacyid, _.userid, _.mayor, V3).fetchAsync().futureValue mustBe List(V3(v.legId, v.userId, v.mayor))
-    base.selectCase(_.legacyid, _.userid, _.mayor, _.mayor_count, V4).fetchAsync().futureValue mustBe List(V4(v.legId, v.userId, v.mayor, v.mayor_count))
-    base.selectCase(_.legacyid, _.userid, _.mayor, _.mayor_count, _.closed, V5).fetchAsync().futureValue mustBe List(V5(v.legId, v.userId, v.mayor, v.mayor_count, v.closed))
-    base.selectCase(_.legacyid, _.userid, _.mayor, _.mayor_count, _.closed, _.tags, V6).fetchAsync().futureValue mustBe List(V6(v.legId, v.userId, v.mayor, v.mayor_count, v.closed, v.tags))
+    base.selectCase(_.legacyid, _.userId, V2).fetchAsync().futureValue mustBe List(V2(v.legId, v.userId))
+    base.selectCase(_.legacyid, _.userId, _.mayor, V3).fetchAsync().futureValue mustBe List(V3(v.legId, v.userId, v.mayor))
+    base.selectCase(_.legacyid, _.userId, _.mayor, _.mayor_count, V4).fetchAsync().futureValue mustBe List(V4(v.legId, v.userId, v.mayor, v.mayor_count))
+    base.selectCase(_.legacyid, _.userId, _.mayor, _.mayor_count, _.closed, V5).fetchAsync().futureValue mustBe List(V5(v.legId, v.userId, v.mayor, v.mayor_count, v.closed))
+    base.selectCase(_.legacyid, _.userId, _.mayor, _.mayor_count, _.closed, _.tags, V6).fetchAsync().futureValue mustBe List(V6(v.legId, v.userId, v.mayor, v.mayor_count, v.closed, v.tags))
 
   }
 
@@ -245,7 +245,7 @@ class EndToEndBsonAsyncSpec extends FlatSpec with MustMatchers with ScalaFutures
   "Find and modify" should "work as expected" in {
 
     val v1 = VenueR.where(_.venuename eqs "v1")
-      .findAndModify(_.userid setTo 5) //all required fields have to be set, because they are required in CC
+      .findAndModify(_.userId setTo 5) //all required fields have to be set, because they are required in CC
       .and(_.legacyid setTo 0L).and(_.venuename setTo "").and(_.mayor_count setTo 0L)
       .and(_.closed setTo false).and(_.last_updated setTo LocalDateTime.now())
       .and(_.status setTo VenueStatus.open).and(_.mayor setTo 0L)
@@ -253,21 +253,21 @@ class EndToEndBsonAsyncSpec extends FlatSpec with MustMatchers with ScalaFutures
 
     v1 mustBe None
     val v2 = VenueR.where(_.venuename eqs "v2")
-      .findAndModify(_.userid setTo 5)
+      .findAndModify(_.userId setTo 5)
       .and(_.legacyid setTo 0L).and(_.mayor_count setTo 0L)
       .and(_.closed setTo false).and(_.last_updated setTo LocalDateTime.now())
-      .and(_.status setTo VenueStatus.open).and(_.mayor setTo 0L).and(_.userid setTo 0L)
+      .and(_.status setTo VenueStatus.open).and(_.mayor setTo 0L).and(_.userId setTo 0L)
       .upsertOneAsync(returnNew = true).futureValue
 
     v2.map(_.userId) mustBe Some(5)
 
     val v3 = VenueR.where(_.venuename eqs "v2")
-      .findAndModify(_.userid setTo 6)
+      .findAndModify(_.userId setTo 6)
       .upsertOneAsync(returnNew = false).futureValue
     v3.map(_.userId) mustBe Some(5)
 
     val v4 = VenueR.where(_.venuename eqs "v2")
-      .findAndModify(_.userid setTo 7)
+      .findAndModify(_.userId setTo 7)
       .upsertOneAsync(returnNew = true).futureValue
     v4.map(_.userId) mustBe Some(7)
   }
@@ -310,8 +310,8 @@ class EndToEndBsonAsyncSpec extends FlatSpec with MustMatchers with ScalaFutures
     (1 to 5).foreach(_ => VenueR.insertOneAsync(baseTestVenue().copy(userId = 1L)).futureValue)
     (1 to 5).foreach(_ => VenueR.insertOneAsync(baseTestVenue().copy(userId = 2L)).futureValue)
     (1 to 5).foreach(_ => VenueR.insertOneAsync(baseTestVenue().copy(userId = 3L)).futureValue)
-    VenueR.where(_.mayor eqs 789L).distinctAsync(_.userid).futureValue.length mustBe 3
-    VenueR.where(_.mayor eqs 789L).countDistinctAsync(_.userid).futureValue mustBe 3
+    VenueR.where(_.mayor eqs 789L).distinctAsync(_.userId).futureValue.length mustBe 3
+    VenueR.where(_.mayor eqs 789L).countDistinctAsync(_.userId).futureValue mustBe 3
   }
 
   "Slice" should "work as expected" in {
@@ -333,7 +333,7 @@ class EndToEndBsonAsyncSpec extends FlatSpec with MustMatchers with ScalaFutures
     VenueR.select(_.firstClaim).fetchAsync()
       .futureValue must contain(VenueClaimBson.default)
 
-    VenueR.select(_.userid, _.firstClaim).fetchAsync()
+    VenueR.select(_.userId, _.firstClaim).fetchAsync()
       .futureValue must contain(456L -> VenueClaimBson.default)
 
     val yetAnotherClaim = VenueClaimBson.default.copy(uid = 1L)

--- a/cc/src/test/scala/me/sgrouples/rogue/cc/EndToEndBsonTest.scala
+++ b/cc/src/test/scala/me/sgrouples/rogue/cc/EndToEndBsonTest.scala
@@ -23,7 +23,7 @@ class EndToEndBsonTest extends JUnitMustMatchers {
   val firstClaim = VenueClaimBson(uid = 5679L, status = ClaimStatus.approved)
 
   def baseTestVenue(): Venue = Venue(
-    _id = new ObjectId(),
+    _id = Venue.newId,
     legId = 123L,
     userId = 456L,
     venuename = "test venue",
@@ -43,7 +43,7 @@ class EndToEndBsonTest extends JUnitMustMatchers {
   )
 
   def baseTestVenueClaim(vid: ObjectId): VenueClaim = {
-    VenueClaim(new ObjectId(), vid, 123L, ClaimStatus.approved)
+    VenueClaim(VenueClaim.newId, vid, 123L, ClaimStatus.approved)
   }
 
   def baseTestTip(): Tip = {

--- a/cc/src/test/scala/me/sgrouples/rogue/cc/EndToEndBsonTest.scala
+++ b/cc/src/test/scala/me/sgrouples/rogue/cc/EndToEndBsonTest.scala
@@ -134,11 +134,11 @@ class EndToEndBsonTest extends JUnitMustMatchers {
 
     base.select(_.legacyid).fetch() must_== List(v.legId)
 
-    val x = base.select(_.legacyid, _.userid).fetch() must_== List((v.legId, v.userId))
-    base.select(_.legacyid, _.userid, _.mayor).fetch() must_== List((v.legId, v.userId, v.mayor))
-    base.select(_.legacyid, _.userid, _.mayor, _.mayor_count).fetch() must_== List((v.legId, v.userId, v.mayor, v.mayor_count))
-    base.select(_.legacyid, _.userid, _.mayor, _.mayor_count, _.closed).fetch() must_== List((v.legId, v.userId, v.mayor, v.mayor_count, v.closed))
-    base.select(_.legacyid, _.userid, _.mayor, _.mayor_count, _.closed, _.tags).fetch() must_== List((v.legId, v.userId, v.mayor, v.mayor_count, v.closed, v.tags))
+    val x = base.select(_.legacyid, _.userId).fetch() must_== List((v.legId, v.userId))
+    base.select(_.legacyid, _.userId, _.mayor).fetch() must_== List((v.legId, v.userId, v.mayor))
+    base.select(_.legacyid, _.userId, _.mayor, _.mayor_count).fetch() must_== List((v.legId, v.userId, v.mayor, v.mayor_count))
+    base.select(_.legacyid, _.userId, _.mayor, _.mayor_count, _.closed).fetch() must_== List((v.legId, v.userId, v.mayor, v.mayor_count, v.closed))
+    base.select(_.legacyid, _.userId, _.mayor, _.mayor_count, _.closed, _.tags).fetch() must_== List((v.legId, v.userId, v.mayor, v.mayor_count, v.closed, v.tags))
   }
 
   @Test
@@ -155,11 +155,11 @@ class EndToEndBsonTest extends JUnitMustMatchers {
 
     val base = VenueR.where(_.id eqs v._id)
     base.selectCase(_.legacyid, V1).fetch() must_== List(V1(v.legId))
-    base.selectCase(_.legacyid, _.userid, V2).fetch() must_== List(V2(v.legId, v.userId))
-    base.selectCase(_.legacyid, _.userid, _.mayor, V3).fetch() must_== List(V3(v.legId, v.userId, v.mayor))
-    base.selectCase(_.legacyid, _.userid, _.mayor, _.mayor_count, V4).fetch() must_== List(V4(v.legId, v.userId, v.mayor, v.mayor_count))
-    base.selectCase(_.legacyid, _.userid, _.mayor, _.mayor_count, _.closed, V5).fetch() must_== List(V5(v.legId, v.userId, v.mayor, v.mayor_count, v.closed))
-    base.selectCase(_.legacyid, _.userid, _.mayor, _.mayor_count, _.closed, _.tags, V6).fetch() must_== List(V6(v.legId, v.userId, v.mayor, v.mayor_count, v.closed, v.tags))
+    base.selectCase(_.legacyid, _.userId, V2).fetch() must_== List(V2(v.legId, v.userId))
+    base.selectCase(_.legacyid, _.userId, _.mayor, V3).fetch() must_== List(V3(v.legId, v.userId, v.mayor))
+    base.selectCase(_.legacyid, _.userId, _.mayor, _.mayor_count, V4).fetch() must_== List(V4(v.legId, v.userId, v.mayor, v.mayor_count))
+    base.selectCase(_.legacyid, _.userId, _.mayor, _.mayor_count, _.closed, V5).fetch() must_== List(V5(v.legId, v.userId, v.mayor, v.mayor_count, v.closed))
+    base.selectCase(_.legacyid, _.userId, _.mayor, _.mayor_count, _.closed, _.tags, V6).fetch() must_== List(V6(v.legId, v.userId, v.mayor, v.mayor_count, v.closed, v.tags))
   }
 
   @Test
@@ -254,7 +254,7 @@ class EndToEndBsonTest extends JUnitMustMatchers {
   @Test
   def testFindAndModify {
     val v1 = VenueR.where(_.venuename eqs "v1")
-      .findAndModify(_.userid setTo 5) //all required fields have to be set, because they are required in CC
+      .findAndModify(_.userId setTo 5) //all required fields have to be set, because they are required in CC
       .and(_.legacyid setTo 0L).and(_.venuename setTo "").and(_.mayor_count setTo 0L)
       .and(_.closed setTo false).and(_.last_updated setTo LocalDateTime.now())
       .and(_.status setTo VenueStatus.open).and(_.mayor setTo 0L)
@@ -262,21 +262,21 @@ class EndToEndBsonTest extends JUnitMustMatchers {
 
     v1 must_== None
     val v2 = VenueR.where(_.venuename eqs "v2")
-      .findAndModify(_.userid setTo 5)
+      .findAndModify(_.userId setTo 5)
       .and(_.legacyid setTo 0L).and(_.mayor_count setTo 0L)
       .and(_.closed setTo false).and(_.last_updated setTo LocalDateTime.now())
-      .and(_.status setTo VenueStatus.open).and(_.mayor setTo 0L).and(_.userid setTo 0L)
+      .and(_.status setTo VenueStatus.open).and(_.mayor setTo 0L).and(_.userId setTo 0L)
       .upsertOne(returnNew = true)
 
     v2.map(_.userId) must_== Some(5)
 
     val v3 = VenueR.where(_.venuename eqs "v2")
-      .findAndModify(_.userid setTo 6)
+      .findAndModify(_.userId setTo 6)
       .upsertOne(returnNew = false)
     v3.map(_.userId) must_== Some(5)
 
     val v4 = VenueR.where(_.venuename eqs "v2")
-      .findAndModify(_.userid setTo 7)
+      .findAndModify(_.userId setTo 7)
       .upsertOne(returnNew = true)
     v4.map(_.userId) must_== Some(7)
 
@@ -320,8 +320,8 @@ class EndToEndBsonTest extends JUnitMustMatchers {
     (1 to 5).foreach(_ => VenueR.insertOne(baseTestVenue().copy(userId = 1L)))
     (1 to 5).foreach(_ => VenueR.insertOne(baseTestVenue().copy(userId = 2L)))
     (1 to 5).foreach(_ => VenueR.insertOne(baseTestVenue().copy(userId = 3L)))
-    VenueR.where(_.mayor eqs 789L).distinct(_.userid).length must_== 3
-    VenueR.where(_.mayor eqs 789L).countDistinct(_.userid) must_== 3
+    VenueR.where(_.mayor eqs 789L).distinct(_.userId).length must_== 3
+    VenueR.where(_.mayor eqs 789L).countDistinct(_.userId) must_== 3
   }
 
   @Test

--- a/cc/src/test/scala/me/sgrouples/rogue/cc/QueryFieldHelperSpec.scala
+++ b/cc/src/test/scala/me/sgrouples/rogue/cc/QueryFieldHelperSpec.scala
@@ -59,11 +59,11 @@ class TestDomainObjectMeta extends RCcMeta[TestDomainObject]
 
   val backwardCompatibilityCheck = new StringField("foo", this)
 
-  val uuid = UUIDField
-  val uuid_name = UUIDField("uuid_name")
+  val uuid = UUIdField
+  val uuid_name = UUIdField("uuid_name")
 
-  val OptUUID = OptUUIDField
-  val OptUUID_name = OptUUIDField("OptUUID_name")
+  val OptUUID = OptUUIdField
+  val OptUUID_name = OptUUIdField("OptUUID_name")
 
   val localDateTime = LocalDateTimeField
   val localDateTime_name = LocalDateTimeField("localDateTime_name")

--- a/cc/src/test/scala/me/sgrouples/rogue/cc/QueryFieldHelperSpec.scala
+++ b/cc/src/test/scala/me/sgrouples/rogue/cc/QueryFieldHelperSpec.scala
@@ -167,7 +167,7 @@ class QueryFieldHelperSpec extends FlatSpec with MustMatchers {
     val a = StringField
   }
 
-  it should "fail when resolving an inner meta class" in {
+  it should "not fail when resolving an inner meta class" in {
     (new DifferentTestMeta).a.name mustBe "a"
   }
 }

--- a/cc/src/test/scala/me/sgrouples/rogue/cc/QueryFieldHelperSpec.scala
+++ b/cc/src/test/scala/me/sgrouples/rogue/cc/QueryFieldHelperSpec.scala
@@ -6,6 +6,7 @@ import org.scalatest.{ FlatSpec, MustMatchers }
 import me.sgrouples.rogue._
 import BsonFormats._
 import EnumNameFormats._
+import me.sgrouples.rogue.cc.Metas.VenueRMeta
 
 case class TestDomainObject(id: ObjectId)
 
@@ -26,9 +27,9 @@ trait TestQueryTraitB[OwnerType] {
 }
 
 class TestDomainObjectMeta extends RCcMeta[TestDomainObject]
-    with QueryFieldHelpers[TestDomainObjectMeta]
-    with TestQueryTraitA[TestDomainObjectMeta]
-    with TestQueryTraitB[TestDomainObjectMeta] {
+    with QueryFieldHelpers[TestDomainObjectMeta] {
+
+  val claims = ListField[String]
 
   val string = StringField
   val string_name = StringField("string_name")
@@ -55,6 +56,8 @@ class TestDomainObjectMeta extends RCcMeta[TestDomainObject]
   val OptObjectId_name = OptObjectIdField("OptObjectId_name")
 
   val randomSomething = 42
+
+  val backwardCompatibilityCheck = new StringField("foo", this)
 
   val uuid = UUIDField
   val uuid_name = UUIDField("uuid_name")
@@ -85,14 +88,15 @@ class TestDomainObjectMeta extends RCcMeta[TestDomainObject]
 class QueryFieldHelperSpec extends FlatSpec with MustMatchers {
 
   val TestDomainObjects = new TestDomainObjectMeta
+  val V = new VenueRMeta
 
   "QueryFieldHelper" should "auto-resolve field names" in {
 
-    TestDomainObjects.int.name mustBe "int"
-    TestDomainObjects.int_name.name mustBe "int_name"
-
-    TestDomainObjects.OptInt.name mustBe "OptInt"
-    TestDomainObjects.OptInt_name.name mustBe "OptInt_name"
+    //    TestDomainObjects.int.name mustBe "int"
+    //    TestDomainObjects.int_name.name mustBe "int_name"
+    //
+    //    TestDomainObjects.OptInt.name mustBe "OptInt"
+    //    TestDomainObjects.OptInt_name.name mustBe "OptInt_name"
 
     TestDomainObjects.string.name mustBe "string"
     TestDomainObjects.string_name.name mustBe "string_name"

--- a/cc/src/test/scala/me/sgrouples/rogue/cc/QueryFieldHelperSpec.scala
+++ b/cc/src/test/scala/me/sgrouples/rogue/cc/QueryFieldHelperSpec.scala
@@ -27,7 +27,9 @@ trait TestQueryTraitB[OwnerType] {
 }
 
 class TestDomainObjectMeta extends RCcMeta[TestDomainObject]
-    with QueryFieldHelpers[TestDomainObjectMeta] {
+    with QueryFieldHelpers[TestDomainObjectMeta]
+    with TestQueryTraitA[TestDomainObjectMeta]
+    with TestQueryTraitB[TestDomainObjectMeta] {
 
   val claims = ListField[String]
 
@@ -92,11 +94,11 @@ class QueryFieldHelperSpec extends FlatSpec with MustMatchers {
 
   "QueryFieldHelper" should "auto-resolve field names" in {
 
-    //    TestDomainObjects.int.name mustBe "int"
-    //    TestDomainObjects.int_name.name mustBe "int_name"
-    //
-    //    TestDomainObjects.OptInt.name mustBe "OptInt"
-    //    TestDomainObjects.OptInt_name.name mustBe "OptInt_name"
+    TestDomainObjects.int.name mustBe "int"
+    TestDomainObjects.int_name.name mustBe "int_name"
+
+    TestDomainObjects.OptInt.name mustBe "OptInt"
+    TestDomainObjects.OptInt_name.name mustBe "OptInt_name"
 
     TestDomainObjects.string.name mustBe "string"
     TestDomainObjects.string_name.name mustBe "string_name"

--- a/cc/src/test/scala/me/sgrouples/rogue/cc/QueryFieldHelperSpec.scala
+++ b/cc/src/test/scala/me/sgrouples/rogue/cc/QueryFieldHelperSpec.scala
@@ -1,0 +1,146 @@
+package me.sgrouples.rogue.cc
+
+import me.sgrouples.rogue.{ BsonFormats, EnumNameFormats }
+import org.bson.types.ObjectId
+import org.scalatest.{ FlatSpec, MustMatchers }
+import me.sgrouples.rogue._
+import BsonFormats._
+import EnumNameFormats._
+
+case class TestDomainObject(id: ObjectId)
+
+trait TestQueryTraitA[OwnerType] {
+  requires: OwnerType with QueryFieldHelpers[OwnerType] =>
+
+  val int = IntField
+  val int_name = IntField("int_name")
+
+}
+
+trait TestQueryTraitB[OwnerType] {
+  requires: OwnerType with QueryFieldHelpers[OwnerType] =>
+
+  val OptInt = OptIntField
+  val OptInt_name = OptIntField("OptInt_name")
+
+}
+
+class TestDomainObjectMeta extends RCcMeta[TestDomainObject]
+    with QueryFieldHelpers[TestDomainObjectMeta]
+    with TestQueryTraitA[TestDomainObjectMeta]
+    with TestQueryTraitB[TestDomainObjectMeta] {
+
+  val string = StringField
+  val string_name = StringField("string_name")
+
+  val OptString = OptStringField
+  val OptString_name = OptStringField("OptString_name")
+
+  val long = LongField
+  val long_name = LongField("long_name")
+
+  val OptLong = OptLongField
+  val OptLong_name = OptLongField("OptLong_name")
+
+  val double = DoubleField
+  val double_name = DoubleField("double_name")
+
+  val OptDouble = OptDoubleField
+  val OptDouble_name = OptDoubleField("OptDouble_name")
+
+  val objectId = ObjectIdField
+  val objectId_name = ObjectIdField("objectId_name")
+
+  val OptObjectId = OptObjectIdField
+  val OptObjectId_name = OptObjectIdField("OptObjectId_name")
+
+  val randomSomething = 42
+
+  val uuid = UUIDField
+  val uuid_name = UUIDField("uuid_name")
+
+  val OptUUID = OptUUIDField
+  val OptUUID_name = OptUUIDField("OptUUID_name")
+
+  val localDateTime = LocalDateTimeField
+  val localDateTime_name = LocalDateTimeField("localDateTime_name")
+
+  val OptLocalDateTime = OptLocalDateTimeField
+  val OptLocalDateTime_name = OptLocalDateTimeField("OptLocalDateTime_name")
+
+  val instant = InstantField
+  val instant_name = InstantField("instant_name")
+
+  val OptInstant = OptInstantField
+  val OptInstant_name = OptInstantField("OptInstant_name")
+
+  val boolean = BooleanField
+  val boolean_name = BooleanField("boolean_name")
+
+  val OptBoolean = OptBooleanField
+  val OptBoolean_name = OptBooleanField("OptBoolean_name")
+
+}
+
+class QueryFieldHelperSpec extends FlatSpec with MustMatchers {
+
+  val TestDomainObjects = new TestDomainObjectMeta
+
+  "QueryFieldHelper" should "auto-resolve field names" in {
+
+    TestDomainObjects.int.name mustBe "int"
+    TestDomainObjects.int_name.name mustBe "int_name"
+
+    TestDomainObjects.OptInt.name mustBe "OptInt"
+    TestDomainObjects.OptInt_name.name mustBe "OptInt_name"
+
+    TestDomainObjects.string.name mustBe "string"
+    TestDomainObjects.string_name.name mustBe "string_name"
+
+    TestDomainObjects.OptString.name mustBe "OptString"
+    TestDomainObjects.OptString_name.name mustBe "OptString_name"
+
+    TestDomainObjects.long.name mustBe "long"
+    TestDomainObjects.long_name.name mustBe "long_name"
+
+    TestDomainObjects.OptLong.name mustBe "OptLong"
+    TestDomainObjects.OptLong_name.name mustBe "OptLong_name"
+
+    TestDomainObjects.double.name mustBe "double"
+    TestDomainObjects.double_name.name mustBe "double_name"
+
+    TestDomainObjects.OptDouble.name mustBe "OptDouble"
+    TestDomainObjects.OptDouble_name.name mustBe "OptDouble_name"
+
+    TestDomainObjects.objectId.name mustBe "objectId"
+    TestDomainObjects.objectId_name.name mustBe "objectId_name"
+
+    TestDomainObjects.OptObjectId.name mustBe "OptObjectId"
+    TestDomainObjects.OptObjectId_name.name mustBe "OptObjectId_name"
+
+    TestDomainObjects.uuid.name mustBe "uuid"
+    TestDomainObjects.uuid_name.name mustBe "uuid_name"
+
+    TestDomainObjects.OptUUID.name mustBe "OptUUID"
+    TestDomainObjects.OptUUID_name.name mustBe "OptUUID_name"
+
+    TestDomainObjects.localDateTime.name mustBe "localDateTime"
+    TestDomainObjects.localDateTime_name.name mustBe "localDateTime_name"
+
+    TestDomainObjects.OptLocalDateTime.name mustBe "OptLocalDateTime"
+    TestDomainObjects.OptLocalDateTime_name.name mustBe "OptLocalDateTime_name"
+
+    TestDomainObjects.instant.name mustBe "instant"
+    TestDomainObjects.instant_name.name mustBe "instant_name"
+
+    TestDomainObjects.OptInstant.name mustBe "OptInstant"
+    TestDomainObjects.OptInstant_name.name mustBe "OptInstant_name"
+
+    TestDomainObjects.boolean.name mustBe "boolean"
+    TestDomainObjects.boolean_name.name mustBe "boolean_name"
+
+    TestDomainObjects.OptBoolean.name mustBe "OptBoolean"
+    TestDomainObjects.OptBoolean_name.name mustBe "OptBoolean_name"
+
+  }
+}

--- a/cc/src/test/scala/me/sgrouples/rogue/cc/QueryFieldHelperSpec.scala
+++ b/cc/src/test/scala/me/sgrouples/rogue/cc/QueryFieldHelperSpec.scala
@@ -14,139 +14,137 @@ trait TestQueryTraitA[OwnerType] {
   requires: OwnerType with QueryFieldHelpers[OwnerType] =>
 
   val int = IntField
-  val int_name = IntField("int_name")
+  val int_named = IntField("int_custom_name")
 
 }
 
 trait TestQueryTraitB[OwnerType] {
   requires: OwnerType with QueryFieldHelpers[OwnerType] =>
 
-  val OptInt = OptIntField
-  val OptInt_name = OptIntField("OptInt_name")
+  val optInt = OptIntField
+  val optInt_named = OptIntField("optInt_custom_name")
 
 }
 
-class TestDomainObjectMeta extends RCcMeta[TestDomainObject]
-    with QueryFieldHelpers[TestDomainObjectMeta]
+class TestDomainObjectMeta extends RCcMetaExt[TestDomainObject, TestDomainObjectMeta]
     with TestQueryTraitA[TestDomainObjectMeta]
     with TestQueryTraitB[TestDomainObjectMeta] {
 
   val claims = ListField[String]
 
   val string = StringField
-  val string_name = StringField("string_name")
+  val string_named = StringField("string_custom_name")
 
-  val OptString = OptStringField
-  val OptString_name = OptStringField("OptString_name")
+  val optString = OptStringField
+  val optString_named = OptStringField("optString_custom_name")
 
   val long = LongField
-  val long_name = LongField("long_name")
+  val long_named = LongField("long_custom_name")
 
-  val OptLong = OptLongField
-  val OptLong_name = OptLongField("OptLong_name")
+  val optLong = OptLongField
+  val optLong_named = OptLongField("optLong_custom_name")
 
   val double = DoubleField
-  val double_name = DoubleField("double_name")
+  val double_named = DoubleField("double_custom_name")
 
-  val OptDouble = OptDoubleField
-  val OptDouble_name = OptDoubleField("OptDouble_name")
+  val optDouble = OptDoubleField
+  val optDouble_named = OptDoubleField("optDouble_custom_name")
 
   val objectId = ObjectIdField
-  val objectId_name = ObjectIdField("objectId_name")
+  val objectId_named = ObjectIdField("objectId_custom_name")
 
-  val OptObjectId = OptObjectIdField
-  val OptObjectId_name = OptObjectIdField("OptObjectId_name")
+  val optObjectId = OptObjectIdField
+  val optObjectId_named = OptObjectIdField("optObjectId_custom_name")
 
   val randomSomething = 42
 
   val backwardCompatibilityCheck = new StringField("foo", this)
 
   val uuid = UUIdField
-  val uuid_name = UUIdField("uuid_name")
+  val uuid_named = UUIdField("uuid_custom_name")
 
-  val OptUUID = OptUUIdField
-  val OptUUID_name = OptUUIdField("OptUUID_name")
+  val optUUID = OptUUIdField
+  val optUUID_named = OptUUIdField("optUUID_custom_name")
 
   val localDateTime = LocalDateTimeField
-  val localDateTime_name = LocalDateTimeField("localDateTime_name")
+  val localDateTime_named = LocalDateTimeField("localDateTime_custom_name")
 
-  val OptLocalDateTime = OptLocalDateTimeField
-  val OptLocalDateTime_name = OptLocalDateTimeField("OptLocalDateTime_name")
+  val optLocalDateTime = OptLocalDateTimeField
+  val optLocalDateTime_named = OptLocalDateTimeField("optLocalDateTime_custom_name")
 
   val instant = InstantField
-  val instant_name = InstantField("instant_name")
+  val instant_named = InstantField("instant_custom_name")
 
-  val OptInstant = OptInstantField
-  val OptInstant_name = OptInstantField("OptInstant_name")
+  val optInstant = OptInstantField
+  val optInstant_named = OptInstantField("optInstant_custom_name")
 
   val boolean = BooleanField
-  val boolean_name = BooleanField("boolean_name")
+  val boolean_named = BooleanField("boolean_custom_name")
 
-  val OptBoolean = OptBooleanField
-  val OptBoolean_name = OptBooleanField("OptBoolean_name")
+  val optBoolean = OptBooleanField
+  val optBoolean_named = OptBooleanField("optBoolean_custom_name")
 
 }
 
 class QueryFieldHelperSpec extends FlatSpec with MustMatchers {
 
   val TestDomainObjects = new TestDomainObjectMeta
-  val V = new VenueRMeta
 
   "QueryFieldHelper" should "auto-resolve field names" in {
 
     TestDomainObjects.int.name mustBe "int"
-    TestDomainObjects.int_name.name mustBe "int_name"
+    TestDomainObjects.int_named.name mustBe "int_custom_name"
 
-    TestDomainObjects.OptInt.name mustBe "OptInt"
-    TestDomainObjects.OptInt_name.name mustBe "OptInt_name"
+    TestDomainObjects.optInt.name mustBe "optInt"
+    TestDomainObjects.optInt_named.name mustBe "optInt_custom_name"
 
     TestDomainObjects.string.name mustBe "string"
-    TestDomainObjects.string_name.name mustBe "string_name"
+    TestDomainObjects.string_named.name mustBe "string_custom_name"
 
-    TestDomainObjects.OptString.name mustBe "OptString"
-    TestDomainObjects.OptString_name.name mustBe "OptString_name"
+    TestDomainObjects.optString.name mustBe "optString"
+    TestDomainObjects.optString_named.name mustBe "optString_custom_name"
 
     TestDomainObjects.long.name mustBe "long"
-    TestDomainObjects.long_name.name mustBe "long_name"
+    TestDomainObjects.long_named.name mustBe "long_custom_name"
 
-    TestDomainObjects.OptLong.name mustBe "OptLong"
-    TestDomainObjects.OptLong_name.name mustBe "OptLong_name"
+    TestDomainObjects.optLong.name mustBe "optLong"
+    TestDomainObjects.optLong_named.name mustBe "optLong_custom_name"
 
     TestDomainObjects.double.name mustBe "double"
-    TestDomainObjects.double_name.name mustBe "double_name"
+    TestDomainObjects.double_named.name mustBe "double_custom_name"
 
-    TestDomainObjects.OptDouble.name mustBe "OptDouble"
-    TestDomainObjects.OptDouble_name.name mustBe "OptDouble_name"
+    TestDomainObjects.optDouble.name mustBe "optDouble"
+    TestDomainObjects.optDouble_named.name mustBe "optDouble_custom_name"
 
     TestDomainObjects.objectId.name mustBe "objectId"
-    TestDomainObjects.objectId_name.name mustBe "objectId_name"
+    TestDomainObjects.objectId_named.name mustBe "objectId_custom_name"
 
-    TestDomainObjects.OptObjectId.name mustBe "OptObjectId"
-    TestDomainObjects.OptObjectId_name.name mustBe "OptObjectId_name"
+    TestDomainObjects.optObjectId.name mustBe "optObjectId"
+    TestDomainObjects.optObjectId_named.name mustBe "optObjectId_custom_name"
 
     TestDomainObjects.uuid.name mustBe "uuid"
-    TestDomainObjects.uuid_name.name mustBe "uuid_name"
+    TestDomainObjects.uuid_named.name mustBe "uuid_custom_name"
 
-    TestDomainObjects.OptUUID.name mustBe "OptUUID"
-    TestDomainObjects.OptUUID_name.name mustBe "OptUUID_name"
+    TestDomainObjects.optUUID.name mustBe "optUUID"
+    TestDomainObjects.optUUID_named.name mustBe "optUUID_custom_name"
 
     TestDomainObjects.localDateTime.name mustBe "localDateTime"
-    TestDomainObjects.localDateTime_name.name mustBe "localDateTime_name"
+    TestDomainObjects.localDateTime_named.name mustBe "localDateTime_custom_name"
 
-    TestDomainObjects.OptLocalDateTime.name mustBe "OptLocalDateTime"
-    TestDomainObjects.OptLocalDateTime_name.name mustBe "OptLocalDateTime_name"
+    TestDomainObjects.optLocalDateTime.name mustBe "optLocalDateTime"
+    TestDomainObjects.optLocalDateTime_named.name mustBe "optLocalDateTime_custom_name"
 
     TestDomainObjects.instant.name mustBe "instant"
-    TestDomainObjects.instant_name.name mustBe "instant_name"
+    TestDomainObjects.instant_named.name mustBe "instant_custom_name"
 
-    TestDomainObjects.OptInstant.name mustBe "OptInstant"
-    TestDomainObjects.OptInstant_name.name mustBe "OptInstant_name"
+    TestDomainObjects.optInstant.name mustBe "optInstant"
+    TestDomainObjects.optInstant_named.name mustBe "optInstant_custom_name"
 
     TestDomainObjects.boolean.name mustBe "boolean"
-    TestDomainObjects.boolean_name.name mustBe "boolean_name"
+    TestDomainObjects.boolean_named.name mustBe "boolean_custom_name"
 
-    TestDomainObjects.OptBoolean.name mustBe "OptBoolean"
-    TestDomainObjects.OptBoolean_name.name mustBe "OptBoolean_name"
+    TestDomainObjects.optBoolean.name mustBe "optBoolean"
+    TestDomainObjects.optBoolean_named.name mustBe "optBoolean_custom_name"
 
   }
 }

--- a/cc/src/test/scala/me/sgrouples/rogue/cc/QueryFieldHelperSpec.scala
+++ b/cc/src/test/scala/me/sgrouples/rogue/cc/QueryFieldHelperSpec.scala
@@ -8,6 +8,8 @@ import BsonFormats._
 import EnumNameFormats._
 import me.sgrouples.rogue.cc.Metas.VenueRMeta
 
+import scala.util.Try
+
 case class TestDomainObject(id: ObjectId)
 
 trait TestQueryTraitA[OwnerType] {
@@ -145,6 +147,29 @@ class QueryFieldHelperSpec extends FlatSpec with MustMatchers {
 
     TestDomainObjects.optBoolean.name mustBe "optBoolean"
     TestDomainObjects.optBoolean_named.name mustBe "optBoolean_custom_name"
+
+  }
+
+  case class AnotherValue(a: String)
+
+  class AnotherTestMeta extends RCcMetaExt[AnotherValue, AnotherTestMeta] {
+    val a = StringField
+    val b = StringField("a")
+  }
+
+  it should "fail when name is duplicated" in {
+    Try(new AnotherTestMeta).toString mustBe "Failure(java.lang.IllegalArgumentException: Field with name a is already defined)"
+  }
+
+  it should "fail when resolving an inner meta class" in {
+
+    case class AnotherValue(a: String)
+
+    class AnotherTestMeta extends RCcMetaExt[AnotherValue, AnotherTestMeta] {
+      val a = StringField
+    }
+
+    Try(new AnotherTestMeta).toString mustBe "Failure(java.lang.IllegalStateException: Couldn't auto-resolve field names, make sure that meta class is not an inner class...)"
 
   }
 }

--- a/cc/src/test/scala/me/sgrouples/rogue/cc/QueryFieldHelperSpec.scala
+++ b/cc/src/test/scala/me/sgrouples/rogue/cc/QueryFieldHelperSpec.scala
@@ -161,15 +161,13 @@ class QueryFieldHelperSpec extends FlatSpec with MustMatchers {
     Try(new AnotherTestMeta).toString mustBe "Failure(java.lang.IllegalArgumentException: Field with name a is already defined)"
   }
 
+  case class DifferentValue(a: String)
+
+  class DifferentTestMeta extends RCcMetaExt[DifferentValue, DifferentTestMeta] {
+    val a = StringField
+  }
+
   it should "fail when resolving an inner meta class" in {
-
-    case class AnotherValue(a: String)
-
-    class AnotherTestMeta extends RCcMetaExt[AnotherValue, AnotherTestMeta] {
-      val a = StringField
-    }
-
-    Try(new AnotherTestMeta).toString mustBe "Failure(java.lang.IllegalStateException: Couldn't auto-resolve field names, make sure that meta class is not an inner class...)"
-
+    (new DifferentTestMeta).a.name mustBe "a"
   }
 }

--- a/cc/src/test/scala/me/sgrouples/rogue/cc/QueryTest.scala
+++ b/cc/src/test/scala/me/sgrouples/rogue/cc/QueryTest.scala
@@ -179,26 +179,26 @@ class QueryTest extends JUnitMustMatchers {
 
     // ordered queries
     VenueR.where(_.mayor eqs 1).orderAsc(_.legacyid).toString() must_== """db.venues.find({ "mayor" : 1}).sort({ "legId" : 1})"""
-    VenueR.where(_.mayor eqs 1).orderDesc(_.legacyid).andAsc(_.userid).toString() must_== """db.venues.find({ "mayor" : 1}).sort({ "legId" : -1 , "userId" : 1})"""
+    VenueR.where(_.mayor eqs 1).orderDesc(_.legacyid).andAsc(_.userId).toString() must_== """db.venues.find({ "mayor" : 1}).sort({ "legId" : -1 , "userId" : 1})"""
     VenueR.where(_.mayor eqs 1).orderDesc(_.lastClaim.subfield(_.date)).toString() must_== """db.venues.find({ "mayor" : 1}).sort({ "lastClaim.date" : -1})"""
     VenueR.where(_.mayor eqs 1).orderNaturalAsc.toString() must_== """db.venues.find({ "mayor" : 1}).sort({ "$natural" : 1})"""
     VenueR.where(_.mayor eqs 1).orderNaturalDesc.toString() must_== """db.venues.find({ "mayor" : 1}).sort({ "$natural" : -1})"""
 
     // select queries
     VenueR.where(_.mayor eqs 1).select(_.legacyid).toString() must_== """db.venues.find({ "mayor" : 1}, { "legId" : 1})"""
-    VenueR.where(_.mayor eqs 1).select(_.legacyid, _.userid).toString() must_== """db.venues.find({ "mayor" : 1}, { "legId" : 1 , "userId" : 1})"""
-    VenueR.where(_.mayor eqs 1).select(_.legacyid, _.userid, _.mayor).toString() must_== """db.venues.find({ "mayor" : 1}, { "legId" : 1 , "userId" : 1 , "mayor" : 1})"""
-    VenueR.where(_.mayor eqs 1).select(_.legacyid, _.userid, _.mayor, _.mayor_count).toString() must_== """db.venues.find({ "mayor" : 1}, { "legId" : 1 , "userId" : 1 , "mayor" : 1 , "mayor_count" : 1})"""
-    VenueR.where(_.mayor eqs 1).select(_.legacyid, _.userid, _.mayor, _.mayor_count, _.closed).toString() must_== """db.venues.find({ "mayor" : 1}, { "legId" : 1 , "userId" : 1 , "mayor" : 1 , "mayor_count" : 1 , "closed" : 1})"""
-    VenueR.where(_.mayor eqs 1).select(_.legacyid, _.userid, _.mayor, _.mayor_count, _.closed, _.tags).toString() must_== """db.venues.find({ "mayor" : 1}, { "legId" : 1 , "userId" : 1 , "mayor" : 1 , "mayor_count" : 1 , "closed" : 1 , "tags" : 1})"""
+    VenueR.where(_.mayor eqs 1).select(_.legacyid, _.userId).toString() must_== """db.venues.find({ "mayor" : 1}, { "legId" : 1 , "userId" : 1})"""
+    VenueR.where(_.mayor eqs 1).select(_.legacyid, _.userId, _.mayor).toString() must_== """db.venues.find({ "mayor" : 1}, { "legId" : 1 , "userId" : 1 , "mayor" : 1})"""
+    VenueR.where(_.mayor eqs 1).select(_.legacyid, _.userId, _.mayor, _.mayor_count).toString() must_== """db.venues.find({ "mayor" : 1}, { "legId" : 1 , "userId" : 1 , "mayor" : 1 , "mayor_count" : 1})"""
+    VenueR.where(_.mayor eqs 1).select(_.legacyid, _.userId, _.mayor, _.mayor_count, _.closed).toString() must_== """db.venues.find({ "mayor" : 1}, { "legId" : 1 , "userId" : 1 , "mayor" : 1 , "mayor_count" : 1 , "closed" : 1})"""
+    VenueR.where(_.mayor eqs 1).select(_.legacyid, _.userId, _.mayor, _.mayor_count, _.closed, _.tags).toString() must_== """db.venues.find({ "mayor" : 1}, { "legId" : 1 , "userId" : 1 , "mayor" : 1 , "mayor_count" : 1 , "closed" : 1 , "tags" : 1})"""
 
     // select case queries
     VenueR.where(_.mayor eqs 1).selectCase(_.legacyid, V1).toString() must_== """db.venues.find({ "mayor" : 1}, { "legId" : 1})"""
-    VenueR.where(_.mayor eqs 1).selectCase(_.legacyid, _.userid, V2).toString() must_== """db.venues.find({ "mayor" : 1}, { "legId" : 1 , "userId" : 1})"""
-    VenueR.where(_.mayor eqs 1).selectCase(_.legacyid, _.userid, _.mayor, V3).toString() must_== """db.venues.find({ "mayor" : 1}, { "legId" : 1 , "userId" : 1 , "mayor" : 1})"""
-    VenueR.where(_.mayor eqs 1).selectCase(_.legacyid, _.userid, _.mayor, _.mayor_count, V4).toString() must_== """db.venues.find({ "mayor" : 1}, { "legId" : 1 , "userId" : 1 , "mayor" : 1 , "mayor_count" : 1})"""
-    VenueR.where(_.mayor eqs 1).selectCase(_.legacyid, _.userid, _.mayor, _.mayor_count, _.closed, V5).toString() must_== """db.venues.find({ "mayor" : 1}, { "legId" : 1 , "userId" : 1 , "mayor" : 1 , "mayor_count" : 1 , "closed" : 1})"""
-    VenueR.where(_.mayor eqs 1).selectCase(_.legacyid, _.userid, _.mayor, _.mayor_count, _.closed, _.tags, V6).toString() must_== """db.venues.find({ "mayor" : 1}, { "legId" : 1 , "userId" : 1 , "mayor" : 1 , "mayor_count" : 1 , "closed" : 1 , "tags" : 1})"""
+    VenueR.where(_.mayor eqs 1).selectCase(_.legacyid, _.userId, V2).toString() must_== """db.venues.find({ "mayor" : 1}, { "legId" : 1 , "userId" : 1})"""
+    VenueR.where(_.mayor eqs 1).selectCase(_.legacyid, _.userId, _.mayor, V3).toString() must_== """db.venues.find({ "mayor" : 1}, { "legId" : 1 , "userId" : 1 , "mayor" : 1})"""
+    VenueR.where(_.mayor eqs 1).selectCase(_.legacyid, _.userId, _.mayor, _.mayor_count, V4).toString() must_== """db.venues.find({ "mayor" : 1}, { "legId" : 1 , "userId" : 1 , "mayor" : 1 , "mayor_count" : 1})"""
+    VenueR.where(_.mayor eqs 1).selectCase(_.legacyid, _.userId, _.mayor, _.mayor_count, _.closed, V5).toString() must_== """db.venues.find({ "mayor" : 1}, { "legId" : 1 , "userId" : 1 , "mayor" : 1 , "mayor_count" : 1 , "closed" : 1})"""
+    VenueR.where(_.mayor eqs 1).selectCase(_.legacyid, _.userId, _.mayor, _.mayor_count, _.closed, _.tags, V6).toString() must_== """db.venues.find({ "mayor" : 1}, { "legId" : 1 , "userId" : 1 , "mayor" : 1 , "mayor_count" : 1 , "closed" : 1 , "tags" : 1})"""
 
     // select subfields
     TipR.where(_.legacyid eqs 1).select(_.counts at "foo").toString() must_== """db.tips.find({ "legid" : 1}, { "counts.foo" : 1})"""
@@ -428,7 +428,7 @@ class QueryTest extends JUnitMustMatchers {
 
     // ordered queries
     VenueR.where(_.mayor eqs 1).orderAsc(_.legacyid).signature() must_== """db.venues.find({ "mayor" : 0}).sort({ "legId" : 1})"""
-    VenueR.where(_.mayor eqs 1).orderDesc(_.legacyid).andAsc(_.userid).signature() must_== """db.venues.find({ "mayor" : 0}).sort({ "legId" : -1 , "userId" : 1})"""
+    VenueR.where(_.mayor eqs 1).orderDesc(_.legacyid).andAsc(_.userId).signature() must_== """db.venues.find({ "mayor" : 0}).sort({ "legId" : -1 , "userId" : 1})"""
 
     // select queries
     VenueR.where(_.mayor eqs 1).select(_.legacyid).signature() must_== """db.venues.find({ "mayor" : 0})"""
@@ -494,20 +494,20 @@ class QueryTest extends JUnitMustMatchers {
       _.where(_.legacyid eqs 1),
       _.where(_.mayor eqs 2)
     )
-      .modify(_.userid setTo 1).toString() must_== """db.venues.update({ "$or" : [ { "legId" : 1} , { "mayor" : 2}]}, { "$set" : { "userId" : 1}}, false, false)"""
+      .modify(_.userId setTo 1).toString() must_== """db.venues.update({ "$or" : [ { "legId" : 1} , { "mayor" : 2}]}, { "$set" : { "userId" : 1}}, false, false)"""
 
     // $or with optional where clause
     VenueR.or(
       _.where(_.legacyid eqs 1),
       _.whereOpt(None)(_.mayor eqs _)
     )
-      .modify(_.userid setTo 1).toString() must_== """db.venues.update({ "$or" : [ { "legId" : 1}]}, { "$set" : { "userId" : 1}}, false, false)"""
+      .modify(_.userId setTo 1).toString() must_== """db.venues.update({ "$or" : [ { "legId" : 1}]}, { "$set" : { "userId" : 1}}, false, false)"""
 
     VenueR.or(
       _.where(_.legacyid eqs 1),
       _.whereOpt(Some(2))(_.mayor eqs _)
     )
-      .modify(_.userid setTo 1).toString() must_== """db.venues.update({ "$or" : [ { "legId" : 1} , { "mayor" : 2}]}, { "$set" : { "userId" : 1}}, false, false)"""
+      .modify(_.userId setTo 1).toString() must_== """db.venues.update({ "$or" : [ { "legId" : 1} , { "mayor" : 2}]}, { "$set" : { "userId" : 1}}, false, false)"""
 
     // OrQuery syntax
     val q1 = VenueR.where(_.legacyid eqs 1)

--- a/cc/src/test/scala/me/sgrouples/rogue/cc/QueryTest.scala
+++ b/cc/src/test/scala/me/sgrouples/rogue/cc/QueryTest.scala
@@ -185,8 +185,9 @@ class QueryTest extends JUnitMustMatchers {
     VenueR.where(_.mayor eqs 1).orderNaturalDesc.toString() must_== """db.venues.find({ "mayor" : 1}).sort({ "$natural" : -1})"""
 
     // select queries
-    VenueR.where(_.mayor eqs 1).select(_.legacyid).toString() must_== """db.venues.find({ "mayor" : 1}, { "legId" : 1})"""
-    VenueR.where(_.mayor eqs 1).select(_.legacyid, _.userId).toString() must_== """db.venues.find({ "mayor" : 1}, { "legId" : 1 , "userId" : 1})"""
+    VenueR.where(_.mayor eqs 1).select(_.id).toString() must_== """db.venues.find({ "mayor" : 1}, { "id" : 1})"""
+    VenueR.where(_.mayor eqs 1).select(_.id, _.legacyid).toString() must_== """db.venues.find({ "mayor" : 1}, { "id": 1, legId" : 1})"""
+    VenueR.where(_.mayor eqs 1).select(_.id, _.legacyid, _.userId).toString() must_== """db.venues.find({ "mayor" : 1}, { "id": 1, "legId" : 1 , "userId" : 1})"""
     VenueR.where(_.mayor eqs 1).select(_.legacyid, _.userId, _.mayor).toString() must_== """db.venues.find({ "mayor" : 1}, { "legId" : 1 , "userId" : 1 , "mayor" : 1})"""
     VenueR.where(_.mayor eqs 1).select(_.legacyid, _.userId, _.mayor, _.mayor_count).toString() must_== """db.venues.find({ "mayor" : 1}, { "legId" : 1 , "userId" : 1 , "mayor" : 1 , "mayor_count" : 1})"""
     VenueR.where(_.mayor eqs 1).select(_.legacyid, _.userId, _.mayor, _.mayor_count, _.closed).toString() must_== """db.venues.find({ "mayor" : 1}, { "legId" : 1 , "userId" : 1 , "mayor" : 1 , "mayor_count" : 1 , "closed" : 1})"""

--- a/project/RogueSettings.scala
+++ b/project/RogueSettings.scala
@@ -13,7 +13,7 @@ object RogueSettings {
   val nexusSnapshots = "snapshots" at nexus+"repository/maven-snapshots/"
 
   lazy val defaultSettings: Seq[Setting[_]] = Seq(
-    version := "2.5.1-MongoAsync-shapeless-30-SNAPSHOT",
+    version := "2.5.1-MongoAsync-shapeless-31-SNAPSHOT",
     organization := "io.fsq",
     scalaVersion := Version.scala,
     publishMavenStyle := true,

--- a/project/RogueSettings.scala
+++ b/project/RogueSettings.scala
@@ -13,7 +13,7 @@ object RogueSettings {
   val nexusSnapshots = "snapshots" at nexus+"repository/maven-snapshots/"
 
   lazy val defaultSettings: Seq[Setting[_]] = Seq(
-    version := "2.5.1-MongoAsync-shapeless-31-SNAPSHOT",
+    version := "2.5.1-MongoAsync-shapeless-32-SNAPSHOT",
     organization := "io.fsq",
     scalaVersion := Version.scala,
     publishMavenStyle := true,

--- a/project/RogueSettings.scala
+++ b/project/RogueSettings.scala
@@ -13,7 +13,7 @@ object RogueSettings {
   val nexusSnapshots = "snapshots" at nexus+"repository/maven-snapshots/"
 
   lazy val defaultSettings: Seq[Setting[_]] = Seq(
-    version := "2.5.1-MongoAsync-shapeless-32-SNAPSHOT",
+    version := "2.5.1-MongoAsync-shapeless-32,
     organization := "io.fsq",
     scalaVersion := Version.scala,
     publishMavenStyle := true,

--- a/project/RogueSettings.scala
+++ b/project/RogueSettings.scala
@@ -13,7 +13,7 @@ object RogueSettings {
   val nexusSnapshots = "snapshots" at nexus+"repository/maven-snapshots/"
 
   lazy val defaultSettings: Seq[Setting[_]] = Seq(
-    version := "2.5.1-MongoAsync-shapeless-30",
+    version := "2.5.1-MongoAsync-shapeless-30-SNAPSHOT",
     organization := "io.fsq",
     scalaVersion := Version.scala,
     publishMavenStyle := true,

--- a/project/RogueSettings.scala
+++ b/project/RogueSettings.scala
@@ -1,16 +1,21 @@
 // Copyright 2012 Foursquare Labs Inc. All Rights Reserved.
 import sbt._
-import Keys._
+import Keys.{scalaVersion, _}
+
+object Version {
+  val scala = "2.11.8"
+}
 
 object RogueSettings {
+
   val nexus = "https://nexus.groupl.es/"
   val nexusReleases = "releases" at nexus+"repository/maven-releases/"
   val nexusSnapshots = "snapshots" at nexus+"repository/maven-snapshots/"
-	
+
   lazy val defaultSettings: Seq[Setting[_]] = Seq(
     version := "2.5.1-MongoAsync-shapeless-29",
     organization := "io.fsq",
-    scalaVersion := "2.11.8",
+    scalaVersion := Version.scala,
     publishMavenStyle := true,
     publishArtifact in Test := false,
     pomIncludeRepository := { _ => false },
@@ -30,7 +35,7 @@ object RogueSettings {
         }
     },
     credentials += Credentials(Path.userHome / ".ivy2" / ".meweCredentials") ,
-    testOptions in Test ++= Seq(Tests.Setup(() => MongoEmbedded.start), Tests.Cleanup(()=>MongoEmbedded.stop))
+    testOptions in Test ++= Seq(Tests.Setup(() => MongoEmbedded.start), Tests.Cleanup(()=> MongoEmbedded.stop))
 	)
 }
 
@@ -77,5 +82,4 @@ object RogueDependencies {
   val rogueLiftDeps = mongoDeps ++ joda ++ liftDeps ++ liftRecordDeps
 
   val ccDeps = mongoDeps ++ Seq(shapeless)  ++ testDeps
-	
 }

--- a/project/RogueSettings.scala
+++ b/project/RogueSettings.scala
@@ -13,7 +13,7 @@ object RogueSettings {
   val nexusSnapshots = "snapshots" at nexus+"repository/maven-snapshots/"
 
   lazy val defaultSettings: Seq[Setting[_]] = Seq(
-    version := "2.5.1-MongoAsync-shapeless-29",
+    version := "2.5.1-MongoAsync-shapeless-30",
     organization := "io.fsq",
     scalaVersion := Version.scala,
     publishMavenStyle := true,


### PR DESCRIPTION
Where this ugly thing here:

```scala
object VenueClaimR extends RCcMeta[VenueClaim]("venueclaims") {

  val venueid = new ObjectIdField("vid", this)
  val status = new EnumField[ClaimStatus.type, VenueClaimR.type]("status", this)
  val reason = new OptEnumField[RejectReason.type, VenueClaimR.type]("reason", this)
  val userId = new LongField("userId", this)
}
```

Becomes less ugly this:

```scala
class VenueClaimRMeta extends RCcMetaExt[VenueClaim, VenueClaimRMeta]("venueclaims") {

  val venueid = ObjectIdField("vid")
  val status = EnumField[ClaimStatus]
  val reason = OptEnumField[RejectReason]
  val userId = LongField
}
 
val VenueClaimR = new VenueClaimRMeta
```