### PR TITLE
Add `LocaleFormat` and `TimeZone` format.

### DIFF
--- a/cc/src/main/scala/me/sgrouples/rogue/BsonFormats.scala
+++ b/cc/src/main/scala/me/sgrouples/rogue/BsonFormats.scala
@@ -185,7 +185,7 @@ trait BaseBsonFormats {
       Locale.getAvailableLocales.filter(_.toString == value).headOption.getOrElse(defaultValue)
     }
     override def write(l: Locale): BsonValue = new BsonString(l.toString)
-    override def defaultValue: Locale = Locale.ENGLISH
+    override def defaultValue: Locale = Locale.US
   }
 
   private def `@@AnyBsonFormat`[T, Tag](implicit tb: BsonFormat[T]): BasicBsonFormat[T @@ Tag] = {

--- a/cc/src/test/scala/BsonFormatsTests.scala
+++ b/cc/src/test/scala/BsonFormatsTests.scala
@@ -1,4 +1,6 @@
 package me.sgrouples.rogue
+import java.util.{ Locale, TimeZone }
+
 import org.bson.types.ObjectId
 import org.junit.Test
 import BsonFormats._
@@ -90,6 +92,34 @@ class BsonFormatsTests extends JUnitMustMatchers {
     //but don't know how to provide default values in case class field parameters
     b must_== B(W(1), "")
     assert(true)
+  }
+
+  @Test
+  def localeTest(): Unit = {
+    val f = BsonFormat[Locale]
+
+    val locales = Locale.getAvailableLocales
+
+    locales.foreach { locale =>
+      val serialized = f.write(locale)
+      val deserialized = f.read(serialized)
+
+      deserialized mustEqual locale
+    }
+  }
+
+  @Test
+  def timeZoneTest(): Unit = {
+    val f = BsonFormat[TimeZone]
+    val timezones = TimeZone.getAvailableIDs
+
+    timezones.foreach { tzId =>
+      val timeZone = TimeZone.getTimeZone(tzId)
+      val serialized = f.write(timeZone)
+      val deserialized = f.read(serialized)
+
+      deserialized mustEqual timeZone
+    }
   }
 
 }


### PR DESCRIPTION
regarding Locale:
- `Locale#toLanguageTag` and `Locale#fromLanguageTag` do not work for all locales
- I've tried commons-lang `LocaleUtils#toLocale` which did not work for `sr_BA_#Latn` for example.