### PR TITLE
Text index support

### DIFF
--- a/cc/src/main/scala/me/sgrouples/rogue/cc/BsonReadWriteSerializers.scala
+++ b/cc/src/main/scala/me/sgrouples/rogue/cc/BsonReadWriteSerializers.scala
@@ -11,12 +11,12 @@ trait BsonReadWriteSerializers[MB <: CcMeta[_]] extends ReadWriteSerializers[MB]
   override protected def readSerializer[M <: CcMeta[_], R](meta: M, select: Option[MongoSelect[M, R]]): RogueBsonRead[R] = {
     new RogueBsonRead[R] {
       override def fromDocument(dbo: BsonDocument): R = select match {
-        case Some(MongoSelect(fields, transformer)) if fields.isEmpty =>
+        case Some(MongoSelect(fields, transformer, true, _)) if fields.isEmpty =>
           // A MongoSelect clause exists, but has empty fields. Return null.
           // This is used for .exists(), where we just want to check the number
           // of returned results is > 0.
           transformer(null)
-        case Some(MongoSelect(fields, transformer)) =>
+        case Some(MongoSelect(fields, transformer, _, _)) =>
           //TODO - optimze - extract readers for fields up, before using read serializer. this is super -ineffective
           //LiftQueryExecutorHelpers.setInstanceFieldFromDoc(inst, dbo, "_id")
           //println(s"Whole DBO ${dbo} ${dbo.getClass}")
@@ -49,9 +49,9 @@ trait BsonReadWriteSerializers[MB <: CcMeta[_]] extends ReadWriteSerializers[MB]
 
       //same thing, but opt
       override def fromDocumentOpt(dbo: BsonDocument): Option[R] = select match {
-        case Some(MongoSelect(fields, transformer)) if fields.isEmpty =>
+        case Some(MongoSelect(fields, transformer, true, _)) if fields.isEmpty =>
           throw new RuntimeException("empty transformer for fromDocumentOpt not implemented, fields subset return in findAndModify not yet implemented")
-        case Some(MongoSelect(fields, transformer)) =>
+        case Some(MongoSelect(fields, transformer, _, _)) =>
           throw new RuntimeException("fromDocumentOpt with fields subset return in findAndModify not yet implemented")
         case None => {
           //println(s"fromDocumentOpt: ${dbo} ")

--- a/cc/src/main/scala/me/sgrouples/rogue/cc/CcRogue.scala
+++ b/cc/src/main/scala/me/sgrouples/rogue/cc/CcRogue.scala
@@ -26,7 +26,7 @@ trait CcRogue {
         val orCondition = QueryHelpers.orConditionFromQueries(q :: qs)
         Query[M, R, Unordered with Unselected with Unlimited with Unskipped with HasOrClause](
           q.meta, q.collectionName, None, None, None, None, None,
-          AndCondition(Nil, Some(orCondition)), None, None, None
+          AndCondition(Nil, Some(orCondition), None), None, None, None
         )
       }
     }
@@ -37,7 +37,7 @@ trait CcRogue {
    */
   implicit def ccMetaToQueryBuilder[M <: CcMeta[_], R](meta: M with CcMeta[R]): Query[M, R, InitialState] =
     Query[M, R, InitialState](
-      meta, meta.collectionName, None, None, None, None, None, AndCondition(Nil, None), None, None, None
+      meta, meta.collectionName, None, None, None, None, None, AndCondition(Nil, None, None), None, None, None
     )
 
   implicit def metaRecordToIndexBuilder[M <: CcMeta[_]](meta: M): IndexBuilder[M] =
@@ -45,7 +45,7 @@ trait CcRogue {
 
   implicit def ccMetaToInsertQuery[MB <: CcMeta[_], M <: MB, R, State](meta: M): InsertableQuery[MB, M, R, InitialState] = {
     val query = Query[M, R, InitialState](
-      meta, meta.collectionName, None, None, None, None, None, AndCondition(Nil, None), None, None, None
+      meta, meta.collectionName, None, None, None, None, None, AndCondition(Nil, None, None), None, None, None
     )
     InsertableQuery(query, CcBsonExecutors).asInstanceOf[InsertableQuery[MB, M, R, InitialState]]
   }
@@ -77,7 +77,7 @@ trait CcRogue {
 
   implicit def metaRecordToCcQuery[MB <: CcMeta[_], M <: MB, R](meta: M): ExecutableQuery[MB, M, R, InitialState] = {
     val queryBuilder = Query[M, R, InitialState](
-      meta, meta.collectionName, None, None, None, None, None, AndCondition(Nil, None), None, None, None
+      meta, meta.collectionName, None, None, None, None, None, AndCondition(Nil, None, None), None, None, None
     )
 
     val ccQuery = queryToCcQuery(queryBuilder)

--- a/cc/src/main/scala/me/sgrouples/rogue/cc/ExecutableQuery.scala
+++ b/cc/src/main/scala/me/sgrouples/rogue/cc/ExecutableQuery.scala
@@ -56,7 +56,7 @@ case class ExecutableQuery[MB, M <: MB, R, State](
    * Checks if there are any records that match this query.
    */
   def exists()(implicit ev: State <:< Unlimited with Unskipped, db: MongoDatabase): Boolean = {
-    val q = query.copy(select = Some(MongoSelect[M, Null](IndexedSeq.empty, _ => null)))
+    val q = query.copy(select = Some(MongoSelect[M, Null](IndexedSeq.empty, _ => null, true, query.select.flatMap(_.scoreName))))
     ex.sync.fetch(q.limit(1)).size > 0
   }
 
@@ -149,7 +149,7 @@ case class ExecutableQuery[MB, M <: MB, R, State](
   }
 */
   def existsAsync(implicit ev: State <:< Unlimited with Unskipped, dba: MongoAsyncDatabase): Future[Boolean] = {
-    val q = query.copy(select = Some(MongoSelect[M, Null](IndexedSeq.empty, _ => null)))
+    val q = query.copy(select = Some(MongoSelect[M, Null](IndexedSeq.empty, _ => null, true, query.select.flatMap(_.scoreName))))
     ex.async.exists(q.limit(1))
   }
 

--- a/core/src/main/scala/MongoHelpers.scala
+++ b/core/src/main/scala/MongoHelpers.scala
@@ -7,17 +7,35 @@ import java.util.regex.Pattern
 import scala.collection.immutable.ListMap
 
 object MongoHelpers extends Rogue {
-  case class AndCondition(clauses: List[QueryClause[_]], orCondition: Option[OrCondition]) {
-    def isEmpty: Boolean = clauses.isEmpty && orCondition.isEmpty
+  case class AndCondition(clauses: List[QueryClause[_]], orCondition: Option[OrCondition], searchCondition: Option[SearchCondition]) {
+    def isEmpty: Boolean = clauses.isEmpty && orCondition.isEmpty && searchCondition.isEmpty
   }
 
   case class OrCondition(conditions: List[AndCondition])
 
-  sealed case class MongoOrder(terms: List[(String, Boolean)])
+  case class SearchCondition(search: String, language: Option[String])
+
+  sealed trait MongoOrderTerm {
+    def extend(builder: BasicDBObjectBuilder): Unit
+  }
+  case class FieldOrderTerm(field: String, ascending: Boolean) extends MongoOrderTerm {
+    def extend(builder: BasicDBObjectBuilder): Unit =
+      builder.add(field, if (ascending) 1 else -1)
+  }
+  case class NaturalOrderTerm(ascending: Boolean) extends MongoOrderTerm {
+    def extend(builder: BasicDBObjectBuilder): Unit =
+      builder.add("$natural", if (ascending) 1 else -1)
+  }
+  case class ScoreOrderTerm(name: String) extends MongoOrderTerm {
+    def extend(builder: BasicDBObjectBuilder): Unit =
+      builder.push(name).add("$meta", "textScore").pop
+  }
+
+  sealed case class MongoOrder(terms: List[MongoOrderTerm])
 
   sealed case class MongoModify(clauses: List[ModifyClause])
 
-  sealed case class MongoSelect[M, R](fields: IndexedSeq[SelectField[_, M]], transformer: IndexedSeq[Any] => R)
+  sealed case class MongoSelect[M, R](fields: IndexedSeq[SelectField[_, M]], transformer: IndexedSeq[Any] => R, isExists: Boolean, scoreName: Option[String])
 
   object MongoBuilder {
     def buildCondition(cond: AndCondition, signature: Boolean = false): BasicDBObject = {
@@ -68,12 +86,20 @@ object MongoHelpers extends Rogue {
           .filterNot(_.keySet.isEmpty)
         builder.add("$or", QueryHelpers.list(subclauses))
       })
+
+      // Optional $text clause
+      cond.searchCondition.foreach(txt => {
+        builder.push("$text").add("$search", txt.search)
+        txt.language.foreach { lang => builder.add("$language", lang) }
+        builder.pop
+      })
+
       builder.get.asInstanceOf[BasicDBObject]
     }
 
     def buildOrder(o: MongoOrder): BasicDBObject = {
       val builder = BasicDBObjectBuilder.start
-      o.terms.reverse.foreach { case (field, ascending) => builder.add(field, if (ascending) 1 else -1) }
+      o.terms.reverse.foreach(_.extend(builder))
       builder.get.asInstanceOf[BasicDBObject]
     }
 
@@ -91,10 +117,9 @@ object MongoHelpers extends Rogue {
 
     def buildSelect[M, R](select: MongoSelect[M, R]): BasicDBObject = {
       val builder = BasicDBObjectBuilder.start
-      // If select.fields is empty, then a MongoSelect clause exists, but has an empty
-      // list of fields. In this case (used for .exists()), we select just the
-      // _id field.
-      if (select.fields.isEmpty) {
+      // If select.isExists is true, then a MongoSelect clause exists,
+      // and we select just the _id field.
+      if (select.isExists) {
         builder.add("_id", 1)
       } else {
         select.fields.foreach(f => {
@@ -105,6 +130,9 @@ object MongoHelpers extends Rogue {
           }
         })
       }
+
+      // add score "field"
+      select.scoreName.foreach(name => builder.push(name).add("$meta", "textScore").pop)
       builder.get.asInstanceOf[BasicDBObject]
     }
 

--- a/core/src/main/scala/PhantomTypes.scala
+++ b/core/src/main/scala/PhantomTypes.scala
@@ -40,6 +40,12 @@ sealed trait AllShardsOk extends ShardAware
 sealed trait Sh extends ShardKeyNotSpecified with ShardKeySpecified with AllShardsOk
 
 @implicitNotFound(msg = "Query must be Unordered, but it's actually ${In}")
+trait AddNaturalOrder[-In, +Out] extends Required[In, Unordered]
+object AddNaturalOrder {
+  implicit def addOrder[Rest >: Sel with Lim with Sk with Or with Sh]: AddNaturalOrder[Rest with Unordered, Rest with Ordered] = null
+}
+
+@implicitNotFound(msg = "Query must be Unordered, but it's actually ${In}")
 trait AddOrder[-In, +Out] extends Required[In, Unordered]
 object AddOrder {
   implicit def addOrder[Rest >: Sel with Lim with Sk with Or with Hn with Sh]: AddOrder[Rest with Unordered, Rest with Ordered] = null
@@ -120,12 +126,14 @@ sealed trait Index extends Indexable with IndexScannable
 sealed trait PartialIndexScan extends IndexScannable
 sealed trait IndexScan extends IndexScannable
 sealed trait DocumentScan extends MaybeIndexed
+sealed trait TextIndex extends Indexable
 
 case object NoIndexInfo extends NoIndexInfo
 case object Index extends Index
 case object PartialIndexScan extends PartialIndexScan
 case object IndexScan extends IndexScan
 case object DocumentScan extends DocumentScan
+case object TextIndex extends TextIndex
 
 sealed trait MaybeUsedIndex
 sealed trait UsedIndex extends MaybeUsedIndex

--- a/core/src/main/scala/QueryClause.scala
+++ b/core/src/main/scala/QueryClause.scala
@@ -155,7 +155,7 @@ case class ElemMatchWithPredicateClause[V](override val fieldName: String, claus
   override def extend(q: BasicDBObjectBuilder, signature: Boolean): Unit = {
     import io.fsq.rogue.MongoHelpers.AndCondition
     val nested = q.push("$elemMatch")
-    MongoHelpers.MongoBuilder.buildCondition(AndCondition(clauses.toList, None), nested, signature)
+    MongoHelpers.MongoBuilder.buildCondition(AndCondition(clauses.toList, None, None), nested, signature)
     nested.pop
   }
 }
@@ -204,7 +204,7 @@ class ModifyPullWithPredicateClause[V](fieldName: String, clauses: Seq[QueryClau
     extends ModifyClause(ModOps.Pull) {
   override def extend(q: BasicDBObjectBuilder): Unit = {
     import io.fsq.rogue.MongoHelpers.AndCondition
-    MongoHelpers.MongoBuilder.buildCondition(AndCondition(clauses.toList, None), q, false)
+    MongoHelpers.MongoBuilder.buildCondition(AndCondition(clauses.toList, None, None), q, false)
   }
 }
 
@@ -213,7 +213,7 @@ class ModifyPullObjWithPredicateClause[V](fieldName: String, clauses: Seq[QueryC
   override def extend(q: BasicDBObjectBuilder): Unit = {
     import io.fsq.rogue.MongoHelpers.AndCondition
     val nested = q.push(fieldName)
-    MongoHelpers.MongoBuilder.buildCondition(AndCondition(clauses.toList, None), nested, false)
+    MongoHelpers.MongoBuilder.buildCondition(AndCondition(clauses.toList, None, None), nested, false)
     nested.pop
   }
 }

--- a/core/src/main/scala/QueryHelpers.scala
+++ b/core/src/main/scala/QueryHelpers.scala
@@ -76,7 +76,7 @@ object QueryHelpers {
   }
 
   class DefaultQueryConfig extends QueryConfig {
-    override def defaultWriteConcern: WriteConcern = WriteConcern.SAFE
+    override def defaultWriteConcern: WriteConcern = WriteConcern.ACKNOWLEDGED
     /**
      * Batch size to set on the underlying DBCursor.
      * None = take value from the query if specified

--- a/core/src/test/scala/TrivialORMAsyncQueryTest.scala
+++ b/core/src/test/scala/TrivialORMAsyncQueryTest.scala
@@ -80,13 +80,13 @@ object TrivialAsyncORMTests {
       select: Option[MongoSelect[M, R]]
     ): RogueReadSerializer[R] = new RogueReadSerializer[R] {
       override def fromDBObject(dbo: DBObject): R = select match {
-        case Some(MongoSelect(fields, transformer)) if fields.isEmpty =>
+        case Some(MongoSelect(fields, transformer, true, _)) if fields.isEmpty =>
           // A MongoSelect clause exists, but has empty fields. Return null.
           // This is used for .exists(), where we just want to check the number
           // of returned results is > 0.
           transformer(null)
 
-        case Some(MongoSelect(fields, transformer)) =>
+        case Some(MongoSelect(fields, transformer, _, _)) =>
           transformer(fields.map(f => f.valueOrDefault(Option(dbo.get(f.field.name)))))
 
         case None =>
@@ -94,13 +94,13 @@ object TrivialAsyncORMTests {
       }
 
       override def fromDocument(doc: Document): R = select match {
-        case Some(MongoSelect(fields, transformer)) if fields.isEmpty =>
+        case Some(MongoSelect(fields, transformer, true, _)) if fields.isEmpty =>
           // A MongoSelect clause exists, but has empty fields. Return null.
           // This is used for .exists(), where we just want to check the number
           // of returned results is > 0.
           transformer(null)
 
-        case Some(MongoSelect(fields, transformer)) =>
+        case Some(MongoSelect(fields, transformer, _, _)) =>
           transformer(fields.map(f => f.valueOrDefault(Option(doc.get(f.field.name)))))
 
         case None =>
@@ -125,7 +125,7 @@ object TrivialAsyncORMTests {
   object Implicits extends Rogue {
     implicit def meta2Query[M <: Meta[R], R](meta: M with Meta[R]): Query[M, R, InitialState] = {
       Query[M, R, InitialState](
-        meta, meta.collectionName, None, None, None, None, None, AndCondition(Nil, None), None, None, None
+        meta, meta.collectionName, None, None, None, None, None, AndCondition(Nil, None, None), None, None, None
       )
     }
   }

--- a/index/src/main/scala/IndexedRecord.scala
+++ b/index/src/main/scala/IndexedRecord.scala
@@ -8,4 +8,5 @@ package io.fsq.rogue.index
  */
 trait IndexedRecord[M] {
   val mongoIndexList: Seq[MongoIndex[_]] = Vector.empty
+  val mongoTextIndex: Option[MongoTextIndex[_]] = None
 }

--- a/index/src/main/scala/MongoIndex.scala
+++ b/index/src/main/scala/MongoIndex.scala
@@ -174,3 +174,110 @@ case class IndexBuilder[M](rec: M) {
   ): MongoIndex6[M] =
     MongoIndex6[M](f1(rec), m1, f2(rec), m2, f3(rec), m3, f4(rec), m4, f5(rec), m5, f6(rec), m6)
 }
+
+trait MongoTextIndex[R] extends UntypedMongoIndex
+
+case class MongoTextIndexAll[R]() extends MongoTextIndex[R] {
+  def asListMap = ListMap(("$**", "text"))
+}
+
+case class MongoTextIndex1[R](
+    f1: Field[_, R]
+) extends MongoTextIndex[R] {
+  def asListMap = ListMap((f1.name, "text"))
+}
+
+case class MongoTextIndex2[R](
+    f1: Field[_, R],
+    f2: Field[_, R]
+) extends MongoTextIndex[R] {
+  def asListMap = ListMap((f1.name, "text"), (f2.name, "text"))
+}
+
+case class MongoTextIndex3[R](
+    f1: Field[_, R],
+    f2: Field[_, R],
+    f3: Field[_, R]
+) extends MongoTextIndex[R] {
+  def asListMap = ListMap((f1.name, "text"), (f2.name, "text"), (f3.name, "text"))
+}
+
+case class MongoTextIndex4[R](
+    f1: Field[_, R],
+    f2: Field[_, R],
+    f3: Field[_, R],
+    f4: Field[_, R]
+) extends MongoTextIndex[R] {
+  def asListMap = ListMap((f1.name, "text"), (f2.name, "text"), (f3.name, "text"), (f4.name, "text"))
+}
+
+case class MongoTextIndex5[R](
+    f1: Field[_, R],
+    f2: Field[_, R],
+    f3: Field[_, R],
+    f4: Field[_, R],
+    f5: Field[_, R]
+) extends MongoTextIndex[R] {
+  def asListMap = ListMap((f1.name, "text"), (f2.name, "text"), (f3.name, "text"), (f4.name, "text"), (f5.name, "text"))
+}
+
+case class MongoTextIndex6[R](
+    f1: Field[_, R],
+    f2: Field[_, R],
+    f3: Field[_, R],
+    f4: Field[_, R],
+    f5: Field[_, R],
+    f6: Field[_, R]
+) extends MongoTextIndex[R] {
+  def asListMap = ListMap((f1.name, "text"), (f2.name, "text"), (f3.name, "text"), (f4.name, "text"), (f5.name, "text"), (f6.name, "text"))
+}
+
+case class TextIndexBuilder[M](rec: M) {
+  def textIndex(): MongoTextIndexAll[M] =
+    MongoTextIndexAll[M]()
+
+  def textIndex(
+    f1: M => Field[_, M]
+  ): MongoTextIndex1[M] =
+    MongoTextIndex1[M](f1(rec))
+
+  def textIndex(
+    f1: M => Field[_, M],
+    f2: M => Field[_, M]
+  ): MongoTextIndex2[M] =
+    MongoTextIndex2[M](f1(rec), f2(rec))
+
+  def textIndex(
+    f1: M => Field[_, M],
+    f2: M => Field[_, M],
+    f3: M => Field[_, M]
+  ): MongoTextIndex3[M] =
+    MongoTextIndex3[M](f1(rec), f2(rec), f3(rec))
+
+  def textIndex(
+    f1: M => Field[_, M],
+    f2: M => Field[_, M],
+    f3: M => Field[_, M],
+    f4: M => Field[_, M]
+  ): MongoTextIndex4[M] =
+    MongoTextIndex4[M](f1(rec), f2(rec), f3(rec), f4(rec))
+
+  def textIndex(
+    f1: M => Field[_, M],
+    f2: M => Field[_, M],
+    f3: M => Field[_, M],
+    f4: M => Field[_, M],
+    f5: M => Field[_, M]
+  ): MongoTextIndex5[M] =
+    MongoTextIndex5[M](f1(rec), f2(rec), f3(rec), f4(rec), f5(rec))
+
+  def textIndex(
+    f1: M => Field[_, M],
+    f2: M => Field[_, M],
+    f3: M => Field[_, M],
+    f4: M => Field[_, M],
+    f5: M => Field[_, M],
+    f6: M => Field[_, M]
+  ): MongoTextIndex6[M] =
+    MongoTextIndex6[M](f1(rec), f2(rec), f3(rec), f4(rec), f5(rec), f6(rec))
+}

--- a/lift/src/main/scala/ExecutableQuery.scala
+++ b/lift/src/main/scala/ExecutableQuery.scala
@@ -52,7 +52,7 @@ case class ExecutableQuery[MB, M <: MB, RB, R, State](
    * Checks if there are any records that match this query.
    */
   def exists()(implicit ev: State <:< Unlimited with Unskipped): Boolean = {
-    val q = query.copy(select = Some(MongoSelect[M, Null](IndexedSeq.empty, _ => null)))
+    val q = query.copy(select = Some(MongoSelect[M, Null](IndexedSeq.empty, _ => null, true, query.select.flatMap(_.scoreName))))
     db.fetch(q.limit(1)).size > 0
   }
 
@@ -160,7 +160,7 @@ case class ExecutableQuery[MB, M <: MB, RB, R, State](
   }
 
   def existsAsync(implicit ev: State <:< Unlimited with Unskipped): Future[Boolean] = {
-    val q = query.copy(select = Some(MongoSelect[M, Null](IndexedSeq.empty, _ => null)))
+    val q = query.copy(select = Some(MongoSelect[M, Null](IndexedSeq.empty, _ => null, true, query.select.flatMap(_.scoreName))))
     dba.exists(q.limit(1))
   }
 

--- a/lift/src/main/scala/LiftAsyncQueryExecutor.scala
+++ b/lift/src/main/scala/LiftAsyncQueryExecutor.scala
@@ -72,12 +72,12 @@ class LiftAsyncQueryExecutor(override val adapter: MongoAsyncJavaDriverAdapter[M
   ): RogueReadSerializer[R] = {
     new RogueReadSerializer[R] {
       override def fromDBObject(dbo: DBObject): R = select match {
-        case Some(MongoSelect(fields, transformer)) if fields.isEmpty =>
+        case Some(MongoSelect(fields, transformer, true, _)) if fields.isEmpty =>
           // A MongoSelect clause exists, but has empty fields. Return null.
           // This is used for .exists(), where we just want to check the number
           // of returned results is > 0.
           transformer(null)
-        case Some(MongoSelect(fields, transformer)) =>
+        case Some(MongoSelect(fields, transformer, _, _)) =>
           val inst = meta.createRecord.asInstanceOf[MongoRecord[_]]
 
           LiftQueryExecutorHelpers.setInstanceFieldFromDbo(inst, dbo, "_id")
@@ -94,12 +94,12 @@ class LiftAsyncQueryExecutor(override val adapter: MongoAsyncJavaDriverAdapter[M
       }
 
       override def fromDocument(dbo: Document): R = select match {
-        case Some(MongoSelect(fields, transformer)) if fields.isEmpty =>
+        case Some(MongoSelect(fields, transformer, true, _)) if fields.isEmpty =>
           // A MongoSelect clause exists, but has empty fields. Return null.
           // This is used for .exists(), where we just want to check the number
           // of returned results is > 0.
           transformer(null)
-        case Some(MongoSelect(fields, transformer)) =>
+        case Some(MongoSelect(fields, transformer, _, _)) =>
           val inst = meta.createRecord.asInstanceOf[MongoRecord[_]]
 
           LiftQueryExecutorHelpers.setInstanceFieldFromDoc(inst, dbo, "_id")

--- a/lift/src/main/scala/LiftQueryExecutor.scala
+++ b/lift/src/main/scala/LiftQueryExecutor.scala
@@ -71,12 +71,12 @@ class LiftQueryExecutor(
   ): RogueReadSerializer[R] = {
     new RogueReadSerializer[R] {
       override def fromDBObject(dbo: DBObject): R = select match {
-        case Some(MongoSelect(fields, transformer)) if fields.isEmpty =>
+        case Some(MongoSelect(fields, transformer, true, _)) if fields.isEmpty =>
           // A MongoSelect clause exists, but has empty fields. Return null.
           // This is used for .exists(), where we just want to check the number
           // of returned results is > 0.
           transformer(null)
-        case Some(MongoSelect(fields, transformer)) =>
+        case Some(MongoSelect(fields, transformer, _, _)) =>
           val inst = meta.createRecord.asInstanceOf[MongoRecord[_]]
 
           LiftQueryExecutorHelpers.setInstanceFieldFromDbo(inst, dbo, "_id")
@@ -93,12 +93,12 @@ class LiftQueryExecutor(
       }
 
       override def fromDocument(dbo: Document): R = select match {
-        case Some(MongoSelect(fields, transformer)) if fields.isEmpty =>
+        case Some(MongoSelect(fields, transformer, true, _)) if fields.isEmpty =>
           // A MongoSelect clause exists, but has empty fields. Return null.
           // This is used for .exists(), where we just want to check the number
           // of returned results is > 0.
           transformer(null)
-        case Some(MongoSelect(fields, transformer)) =>
+        case Some(MongoSelect(fields, transformer, _, _)) =>
           val inst = meta.createRecord.asInstanceOf[MongoRecord[_]]
 
           LiftQueryExecutorHelpers.setInstanceFieldFromDoc(inst, dbo, "_id")

--- a/lift/src/main/scala/LiftRogue.scala
+++ b/lift/src/main/scala/LiftRogue.scala
@@ -50,7 +50,7 @@ import io.fsq.rogue.{
   Unskipped
 }
 import io.fsq.rogue.MongoHelpers.AndCondition
-import io.fsq.rogue.index.IndexBuilder
+import io.fsq.rogue.index.{ IndexBuilder, TextIndexBuilder }
 import java.util.Date
 import net.liftweb.common.Box.box2Option
 import net.liftweb.json.JsonAST.{ JArray, JInt }
@@ -73,7 +73,7 @@ trait LiftRogue {
         val orCondition = QueryHelpers.orConditionFromQueries(q :: qs)
         Query[M, R, Unordered with Unselected with Unlimited with Unskipped with HasOrClause](
           q.meta, q.collectionName, None, None, None, None, None,
-          AndCondition(Nil, Some(orCondition)), None, None, None
+          AndCondition(Nil, Some(orCondition), None), None, None, None
         )
       }
     }
@@ -84,11 +84,14 @@ trait LiftRogue {
    */
   implicit def metaRecordToQueryBuilder[M <: MongoRecord[M]](rec: M with MongoMetaRecord[M]): Query[M, M, InitialState] =
     Query[M, M, InitialState](
-      rec, rec.collectionName, None, None, None, None, None, AndCondition(Nil, None), None, None, None
+      rec, rec.collectionName, None, None, None, None, None, AndCondition(Nil, None, None), None, None, None
     )
 
   implicit def metaRecordToIndexBuilder[M <: MongoRecord[M]](rec: M with MongoMetaRecord[M]): IndexBuilder[M] =
     IndexBuilder(rec)
+
+  implicit def metaRecordToTextIndexBuilder[M <: MongoRecord[M]](rec: M with MongoMetaRecord[M]): TextIndexBuilder[M] =
+    TextIndexBuilder(rec)
 
   implicit def queryToLiftQuery[M <: MongoRecord[_], R, State](query: Query[M, R, State])(implicit ev: ShardingOk[M with MongoMetaRecord[_], State]): ExecutableQuery[MongoRecord[_] with MongoMetaRecord[_], M with MongoMetaRecord[_], MongoRecord[_], R, State] = {
     ExecutableQuery(

--- a/lift/src/test/scala/EndToEndTest.scala
+++ b/lift/src/test/scala/EndToEndTest.scala
@@ -403,4 +403,26 @@ class EndToEndTest extends JUnitMustMatchers {
     Venue.select(_.tags.slice(-2)).get() must_== Some(List("3", "4"))
     Venue.select(_.tags.slice(1, 2)).get() must_== Some(List("2", "3"))
   }
+
+  @Test
+  def testSearch {
+    import net.liftweb.json.JsonDSL._
+    Venue.createIndex(("venuename" -> "text"))
+    baseTestVenue().legacyid(99).save(true)
+    baseTestVenue().venuename("test venue two").save(true)
+    baseTestVenue().venuename("venue three").save(true)
+
+    Venue.search("venue").select(_.venuename).orderScore().count() must_== 3
+    Venue.search("venue -test").count() must_== 1
+    Venue.search(""" "test venue" """).count() must_== 2
+    Venue.search(""" "test venue" -two """).count() must_== 1
+    Venue.where(_.legacyid eqs 123).search("venue").count() must_== 2
+    Venue.search("aaa").count() must_== 0
+
+    Venue.search("venue").exists() must beTrue
+    Venue.search("aaa").exists() must beFalse
+
+    Venue.searchOpt(Some("venue")).exists() must beTrue
+    Venue.searchOpt(Some("aaa")).exists() must beFalse
+  }
 }

--- a/lift/src/test/scala/QueryExecutorTest.scala
+++ b/lift/src/test/scala/QueryExecutorTest.scala
@@ -21,7 +21,7 @@ class LegacyQueryExecutorTest extends JUnitMustMatchers {
   @Test @Ignore("TODO(mateo): The public version of lift 2.6.2 causes an infinite recursion. FIXME") // Test ignored because it is broken when using OSS version of lift.
   def testExceptionInRunCommandIsDecorated {
     val query = Query[Dummy.type, Dummy, InitialState](
-      Dummy, "Dummy", None, None, None, None, None, AndCondition(Nil, None), None, None, None
+      Dummy, "Dummy", None, None, None, None, None, AndCondition(Nil, None, None), None, None, None
     )
     (LiftAdapter.runCommand(() => "hello", query) {
       throw new RuntimeException("bang")

--- a/lift/src/test/scala/TestModels.scala
+++ b/lift/src/test/scala/TestModels.scala
@@ -118,6 +118,9 @@ object Venue extends Venue with MongoMetaRecord[Venue] {
   val geoCustomIdx = Venue.index(_.geolatlng, CustomIndex, _.tags, Asc)
   override val mongoIndexList = Vector(idIdx, mayorIdIdx, mayorIdClosedIdx, legIdx, geoIdx, geoCustomIdx)
 
+  val textIdx = Venue.textIndex(_.venuename)
+  override val mongoTextIndex = Some(textIdx)
+
   trait FK[T <: FK[T]] extends MongoRecord[T] {
     self: T =>
 


### PR DESCRIPTION
This adds basic support for text search with mongo's text index.

Create the index in your `IndexedRecord`:

    val textIdx = Venue.textIndex(_.venuename)
    override val mongoTextIndex = Some(textIdx)

User the `search` function in your query:

    Venue.search("Starbucks").orderScore()

Notes:

- Using `orderScore()` or `andScore()` will automatically add the
  corresponding term to the select element


--------------

This is the same changeset that was on 4sq's v2 branch but didn't make it to v3: https://github.com/foursquare/rogue/commit/30dc45aadb545e7ebb3645db23a8bc0f14deb1e4

I have our app compiled and tested with this branch, but not in production yet. I'll let you know when that happens.

Fixes #15 
