### PR TITLE
Added caching to bson formats generic reader + some default bson readers

### DIFF
--- a/project/RogueSettings.scala
+++ b/project/RogueSettings.scala
@@ -38,7 +38,7 @@ object RogueSettings {
     commands += Command.single("testOnlyUntilFailed") { (state, param) =>
       s"testOnly $param" :: s"testOnlyUntilFailed $param" :: state
     },
-    version := "5.3.0",
+    version := "5.4.0",
     organization := "me.sgrouples",
     scalaVersion := "2.13.1",
     crossScalaVersions := Seq("2.12.10", "2.13.1"),


### PR DESCRIPTION
Added some default bson formats (for optional values - they are used quite often and shapeless is not handling caching them properly)
Added bsonFormat for Seq[T]
Replaced eager evaluation with caching one for generic bson format.

More info about impact on performance [here](link) 