### PR TITLE
Implement support for `estimatedDocumentCount`

### DIFF
--- a/cc/src/main/scala/me/sgrouples/rogue/cc/ExecutableQuery.scala
+++ b/cc/src/main/scala/me/sgrouples/rogue/cc/ExecutableQuery.scala
@@ -26,6 +26,12 @@ case class ExecutableQuery[MB, M <: MB, R, State](
     */
   def count()(implicit db: MongoDatabase): Long = waitForFuture(countAsync())
 
+  def estimatedDocumentCount()(implicit
+      ev1: Required[State, InitialState],
+      db: MongoDatabase
+  ): Long =
+    waitForFuture(estimatedDocumentCountAsync())
+
   /** Returns the number of distinct values returned by a query. The query must
     * not have limit or skip clauses.
     */
@@ -160,6 +166,12 @@ case class ExecutableQuery[MB, M <: MB, R, State](
   // async ops
   def countAsync()(implicit dba: MongoDatabase): Future[Long] =
     ex.async.count(query)
+
+  def estimatedDocumentCountAsync()(implicit
+      ev1: Required[State, InitialState],
+      dba: MongoDatabase
+  ): Future[Long] =
+    ex.async.estimatedDocumentCount(query)
 
   def foreachAsync(f: R => Unit)(implicit dba: MongoDatabase): Future[Unit] =
     ex.async.foreach(query)(f)
@@ -424,3 +436,4 @@ case class AggregateQuery[MB, M <: MB,  State](collectionName:String, ex: BsonEx
   private[this] def getCollection(db:MongoDatabase, collectionName:String, readPreference: ReadPreference) =
     db.getCollection(collectionName).withReadPreference(readPreference)
 }
+

--- a/cc/src/main/scala/me/sgrouples/rogue/cc/MongoAsyncBsonJavaDriverAdapter.scala
+++ b/cc/src/main/scala/me/sgrouples/rogue/cc/MongoAsyncBsonJavaDriverAdapter.scala
@@ -89,6 +89,15 @@ class MongoAsyncBsonJavaDriverAdapter[MB](
     obs.toFuture()
   }
 
+  def estimatedDocumentCount[M <: MB](
+      query: Query[M, _, _],
+      readPreference: Option[ReadPreference]
+  )(implicit dba: MongoDatabase): Future[Long] = {
+    val coll = getDBCollection(query, readPreference)
+    val obs: SingleObservable[Long] = coll.estimatedDocumentCount()
+    obs.toFuture()
+  }
+
   def exists[M <: MB](
       query: Query[M, _, _],
       readPreference: Option[ReadPreference]

--- a/cc/src/main/scala/me/sgrouples/rogue/cc/QueryExecutor.scala
+++ b/cc/src/main/scala/me/sgrouples/rogue/cc/QueryExecutor.scala
@@ -52,6 +52,17 @@ trait AsyncBsonQueryExecutor[MB] extends ReadWriteSerializers[MB] with Rogue {
     adapter.count(query, readPreference)
   }
 
+  def estimatedDocumentCount[M <: MB, State](
+      query: Query[M, _, State],
+      readPreference: Option[ReadPreference] = None
+  )(implicit
+      ev1: Required[State, InitialState],
+      ev2: ShardingOk[M, State],
+      dba: MongoDatabase
+  ): Future[Long] = {
+    adapter.estimatedDocumentCount(query, readPreference)
+  }
+
   def exists[M <: MB, State](
       query: Query[M, _, State],
       readPreference: Option[ReadPreference] = None

--- a/project/RogueSettings.scala
+++ b/project/RogueSettings.scala
@@ -60,7 +60,7 @@ object RogueSettings {
 }
 
 object RogueDependencies {
-  val mongoVer = "4.5.0"
+  val mongoVer = "4.9.0"
   val nettyVer = "4.1.74.Final"
 
   val bosnDeps = Seq("org.mongodb" % "bson" % mongoVer % Compile)


### PR DESCRIPTION
Unfortunately the existing phantom types don't allow to exclude this from queries that have any `where` clauses but at the same time it feels like a lot of work to add that just for this feature..

Driver update because of this: https://github.com/mongodb/mongo-java-driver/pull/929