### PR TITLE
Support legacy ISO language codes on Java 17

### DIFF
--- a/bsonformats/src/main/scala/me/sgrouples/rogue/SupportedLocales.scala
+++ b/bsonformats/src/main/scala/me/sgrouples/rogue/SupportedLocales.scala
@@ -12,6 +12,12 @@ private[rogue] object SupportedLocales {
     mb += ("nb" -> new Locale(
       "nb"
     )) // norwegian bokmål, missing from getAvailableLocales
+
+    // supporting legacy ISO language codes on Java 17:
+    mb += ("iw" -> new Locale("iw"))
+    mb += ("ji" -> new Locale("ji"))
+    mb += ("in" -> new Locale("in"))
+
     mb.result()
   }
 }


### PR DESCRIPTION
https://bugs.openjdk.org/browse/JDK-8267069