### PR TITLE
Add new 'distinct' method which also supports List|Array|Vector fields

### DIFF
--- a/cc/src/test/scala/me/sgrouples/rogue/cc/macros/Metas.scala
+++ b/cc/src/test/scala/me/sgrouples/rogue/cc/macros/Metas.scala
@@ -1,13 +1,13 @@
 package me.sgrouples.rogue.cc.macros
 
-import java.time.Instant
-import java.util.{Currency, Locale, UUID}
-
+import com.softwaremill.tagging._
 import io.fsq.rogue.index.{Asc, Desc, IndexBuilder}
 import me.sgrouples.rogue.cc._
 import me.sgrouples.rogue.naming.PluralLowerCase
 import org.bson.types.ObjectId
-import com.softwaremill.tagging._
+
+import java.time.Instant
+import java.util.{Currency, Locale, UUID}
 
 case class UuidCc(_id: UUID, s: String, i: Instant = Instant.now())
 
@@ -50,7 +50,7 @@ object Metas {
       ClassRequiredField(VenueClaimBsonR, VenueClaimBson.default)
 
     @f val last_updated = LocalDateTimeField
-    @f val popularity = ListField[Long]
+    @f val popularity = VectorField[Long]
     @f val categories = ListField[ObjectId]
 
     val idIdx = index(id, Asc)


### PR DESCRIPTION
1. I need such functionality to obtain distinct `categories` from DiscoverPost collection, where `categories` is an array. Here's the example of such functionality taken from mongo doc: https://www.mongodb.com/docs/manual/reference/command/distinct/#return-distinct-values-for-an-array-field
2. I am aware that naming is far away from being perfect - suggestions expected.
3. @pchmiele suggested to use this "generic" function to define specific ones for `VectorField`, `ListField` etc. For now I am leaving it as is, expecting more feedback to come.
